### PR TITLE
GH-0020: Expose Wi-Fi signal strength as sensor

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,17 @@ sensor:
     # ... every field from the Fields table below is available
 ```
 
+### Wi-Fi signal strength
+
+The example config also exposes the dongle's Wi-Fi signal strength (RSSI) via ESPHome's built-in [`wifi_signal`](https://esphome.io/components/sensor/wifi_signal.html) platform. It's handy for confirming the outdoor unit has usable coverage:
+
+```yaml
+sensor:
+  - platform: wifi_signal
+    name: WiFi signal strength
+    update_interval: 60s
+```
+
 ### JSON endpoint
 
 Add `expose_json_endpoint: true` to serve all mapped sensors and the underlying raw data as JSON. It needs the `web_server` component:

--- a/example-config/device.yaml
+++ b/example-config/device.yaml
@@ -35,6 +35,9 @@ midea_telemetry:
   expose_json_endpoint: true
 
 sensor:
+  - platform: wifi_signal
+    name: WiFi signal strength
+    update_interval: 60s
   - platform: midea_telemetry
     indoor_ambient_temperature:
       name: Indoor ambient temperature


### PR DESCRIPTION
Add ESPHome's native wifi_signal platform to the example config so the dongle reports RSSI, and document it in the README.