### PR TITLE
Add InfluxDB + Grafana stack for permanent telemetry history

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,10 @@ Example:
 
 This is useful for reverse engineering, scripting, and for using the device without Home Assistant.
 
+### Long-term history (InfluxDB + Grafana)
+
+For a permanent, Home-Assistant-independent history, [`influxdb-grafana/`](influxdb-grafana/) provides a ready-to-run Docker stack: Telegraf polls each dongle's `/json` endpoint, stores the decoded values in InfluxDB v2, and Grafana serves a provisioned dashboard on top. Copy `.env.example` to `.env`, list your dongles in `telegraf.conf`, and `docker compose up -d`. See [influxdb-grafana/README.md](influxdb-grafana/README.md).
+
 ## Flashing
 
 Flash your ESP32 with `esphome`. On macOS:

--- a/influxdb-grafana/.env.example
+++ b/influxdb-grafana/.env.example
@@ -1,0 +1,16 @@
+# Copy to .env and adjust. `docker compose` reads .env automatically.
+# .env is gitignored so your token stays out of the repo.
+
+# --- InfluxDB (created on first boot) ---
+INFLUX_USERNAME=admin
+INFLUX_PASSWORD=change-me-influx
+INFLUX_ORG=midea
+INFLUX_BUCKET=midea
+# How long to keep data. 0s = forever. Examples: 30d, 52w, 0s
+INFLUX_RETENTION=0s
+# All-access admin token. Generate one, e.g.:  openssl rand -hex 32
+INFLUX_TOKEN=change-me-generate-a-long-random-token
+
+# --- Grafana ---
+GRAFANA_USERNAME=admin
+GRAFANA_PASSWORD=change-me-grafana

--- a/influxdb-grafana/.gitignore
+++ b/influxdb-grafana/.gitignore
@@ -1,0 +1,2 @@
+# Local secrets — never commit
+.env

--- a/influxdb-grafana/README.md
+++ b/influxdb-grafana/README.md
@@ -1,0 +1,93 @@
+# InfluxDB + Grafana stack
+
+A self-contained, permanent history for your midea-telemetry dongles. Telegraf
+polls each dongle's `/json` endpoint, writes the decoded values into InfluxDB v2,
+and Grafana renders a provisioned dashboard on top — no Home Assistant required.
+
+```
+ dongle /json  ──▶  Telegraf  ──▶  InfluxDB v2  ──▶  Grafana
+ (every 10 s)                     (bucket: midea)     (auto dashboard)
+```
+
+## Prerequisites
+
+- Docker + Docker Compose
+- Each dongle built with `expose_json_endpoint: true` (pulls in `web_server`),
+  reachable on your network. See the [main README](../README.md#json-endpoint).
+
+## Setup
+
+1. **Configure secrets.** Copy the env template and edit it — set a real Influx
+   token and passwords:
+
+   ```bash
+   cp .env.example .env
+   # generate a token:  openssl rand -hex 32
+   ```
+
+2. **List your dongles.** Edit [`telegraf.conf`](telegraf.conf): one
+   `[[inputs.http]]` block per dongle, each with its URL and a unique `device`
+   tag. The file ships with `bedroom`, `garage`, and `bathroom` as examples.
+
+   > ⚠️ **mDNS caveat.** Inside a bridged Docker container, `*.local` names do
+   > **not** resolve. Use each dongle's **IP address** in `telegraf.conf`
+   > (e.g. `http://192.168.1.42/json`), or — on a Linux host only — uncomment
+   > `network_mode: host` for the telegraf service in `docker-compose.yml` to
+   > share the host's mDNS resolver. Assign the dongles static DHCP leases so
+   > the IPs stay put.
+
+3. **Start it.**
+
+   ```bash
+   docker compose up -d
+   ```
+
+4. **Open Grafana** at http://localhost:3000 (log in with the Grafana
+   credentials from `.env`). The **Midea Telemetry** dashboard is already there
+   under the *Midea Telemetry* folder, with a **Device** dropdown at the top.
+
+## What's provisioned
+
+| Piece | Where |
+|---|---|
+| InfluxDB datasource (Flux) | `grafana/provisioning/datasources/influxdb.yml` |
+| Dashboard provider | `grafana/provisioning/dashboards/dashboards.yml` |
+| Dashboard | `grafana/dashboards/midea-telemetry.json` |
+
+The dashboard groups every field from the [Fields table](../README.md#fields):
+coil/ambient temps, discharge & IPM temps, compressor frequency (target vs
+actual), outdoor fan speed & EEV steps, input/DC-bus voltage, current draw, and
+set-point/operating mode — filtered by the selected device(s).
+
+## Verify data is flowing
+
+```bash
+docker compose logs -f telegraf     # should show no connection errors
+```
+
+In the InfluxDB UI (http://localhost:8086) → *Data Explorer*, query the `midea`
+bucket for measurement `midea`; you should see one series per field, tagged by
+`device`.
+
+## Retention
+
+`INFLUX_RETENTION` in `.env` controls how long data is kept (`0s` = forever).
+Change it before first boot, or adjust the bucket's retention later in the
+InfluxDB UI.
+
+## Common tweaks
+
+- **Poll interval:** `interval` in `telegraf.conf` (`[agent]`). Keep it ≥ the
+  dongle's `update_interval` so you're not polling faster than new frames arrive.
+- **Change the bucket name:** update `INFLUX_BUCKET` in `.env` **and** the hidden
+  `bucket` constant in the dashboard (Dashboard settings → Variables → `bucket`).
+- **Add/remove a dongle:** add or delete an `[[inputs.http]]` block and
+  `docker compose restart telegraf`. New devices appear in the dropdown
+  automatically.
+
+## Reset
+
+```bash
+docker compose down          # stop, keep data
+docker compose down -v       # stop and delete all stored data
+```

--- a/influxdb-grafana/docker-compose.yml
+++ b/influxdb-grafana/docker-compose.yml
@@ -1,0 +1,81 @@
+# Self-contained telemetry pipeline for midea-telemetry-esphome dongles.
+#
+#   Telegraf  ->  polls each dongle's /json endpoint
+#   InfluxDB  ->  stores the decoded sensor values (v2, bucket = $INFLUX_BUCKET)
+#   Grafana   ->  provisioned datasource + dashboard on top of InfluxDB
+#
+# Copy .env.example to .env, edit the dongle URLs in telegraf.conf, then:
+#   docker compose up -d
+#
+# Grafana:  http://localhost:3000   (admin / $GRAFANA_PASSWORD)
+# InfluxDB: http://localhost:8086   (admin / $INFLUX_PASSWORD)
+
+services:
+  influxdb:
+    image: influxdb:2.7
+    container_name: midea-influxdb
+    restart: unless-stopped
+    ports:
+      - "8086:8086"
+    environment:
+      DOCKER_INFLUXDB_INIT_MODE: setup
+      DOCKER_INFLUXDB_INIT_USERNAME: ${INFLUX_USERNAME}
+      DOCKER_INFLUXDB_INIT_PASSWORD: ${INFLUX_PASSWORD}
+      DOCKER_INFLUXDB_INIT_ORG: ${INFLUX_ORG}
+      DOCKER_INFLUXDB_INIT_BUCKET: ${INFLUX_BUCKET}
+      DOCKER_INFLUXDB_INIT_RETENTION: ${INFLUX_RETENTION}
+      DOCKER_INFLUXDB_INIT_ADMIN_TOKEN: ${INFLUX_TOKEN}
+    volumes:
+      - influxdb-data:/var/lib/influxdb2
+      - influxdb-config:/etc/influxdb2
+    healthcheck:
+      test: ["CMD", "influx", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  telegraf:
+    image: telegraf:1.32
+    container_name: midea-telegraf
+    restart: unless-stopped
+    depends_on:
+      influxdb:
+        condition: service_healthy
+    environment:
+      INFLUX_TOKEN: ${INFLUX_TOKEN}
+      INFLUX_ORG: ${INFLUX_ORG}
+      INFLUX_BUCKET: ${INFLUX_BUCKET}
+    volumes:
+      - ./telegraf.conf:/etc/telegraf/telegraf.conf:ro
+    # mDNS ".local" names are NOT resolvable inside a bridged container. If your
+    # telegraf.conf uses <name>.local URLs, either put the dongles' IPs there
+    # instead, or (Linux hosts only) uncomment host networking so the container
+    # shares the host's mDNS resolver:
+    #
+    # network_mode: host
+
+  grafana:
+    image: grafana/grafana-oss:11.3.0
+    container_name: midea-grafana
+    restart: unless-stopped
+    depends_on:
+      influxdb:
+        condition: service_healthy
+    ports:
+      - "3000:3000"
+    environment:
+      GF_SECURITY_ADMIN_USER: ${GRAFANA_USERNAME}
+      GF_SECURITY_ADMIN_PASSWORD: ${GRAFANA_PASSWORD}
+      # Consumed by the provisioned datasource (see provisioning/datasources).
+      INFLUX_TOKEN: ${INFLUX_TOKEN}
+      INFLUX_ORG: ${INFLUX_ORG}
+      INFLUX_BUCKET: ${INFLUX_BUCKET}
+    volumes:
+      - grafana-data:/var/lib/grafana
+      - ./grafana/provisioning:/etc/grafana/provisioning:ro
+      - ./grafana/dashboards:/var/lib/grafana/dashboards:ro
+
+volumes:
+  influxdb-data:
+  influxdb-config:
+  grafana-data:

--- a/influxdb-grafana/grafana/dashboards/midea-telemetry.json
+++ b/influxdb-grafana/grafana/dashboards/midea-telemetry.json
@@ -1,0 +1,459 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": { "type": "grafana", "uid": "-- Grafana --" },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "links": [],
+  "liveNow": false,
+  "refresh": "10s",
+  "schemaVersion": 39,
+  "tags": ["midea", "telemetry", "hvac"],
+  "templating": {
+    "list": [
+      {
+        "hide": 2,
+        "name": "bucket",
+        "type": "constant",
+        "query": "midea",
+        "current": { "text": "midea", "value": "midea" },
+        "options": [
+          { "text": "midea", "value": "midea", "selected": true }
+        ]
+      },
+      {
+        "name": "device",
+        "label": "Device",
+        "type": "query",
+        "datasource": { "type": "influxdb", "uid": "midea-influxdb" },
+        "query": "import \"influxdata/influxdb/schema\"\nschema.tagValues(bucket: \"${bucket}\", tag: \"device\", predicate: (r) => true, start: -30d)",
+        "refresh": 2,
+        "sort": 1,
+        "multi": true,
+        "includeAll": true,
+        "current": { "text": "All", "value": ["$__all"] }
+      }
+    ]
+  },
+  "time": { "from": "now-6h", "to": "now" },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Midea Telemetry",
+  "uid": "midea-telemetry",
+  "version": 1,
+  "weekStart": "",
+  "panels": [
+    {
+      "id": 1,
+      "type": "stat",
+      "title": "Compressor frequency (actual)",
+      "datasource": { "type": "influxdb", "uid": "midea-influxdb" },
+      "gridPos": { "h": 4, "w": 6, "x": 0, "y": 0 },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "hertz",
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "blue", "value": null },
+              { "color": "green", "value": 1 },
+              { "color": "orange", "value": 60 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": { "type": "influxdb", "uid": "midea-influxdb" },
+          "refId": "A",
+          "query": "from(bucket: \"${bucket}\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"midea\")\n  |> filter(fn: (r) => r._field == \"compressor_frequency_actual\")\n  |> filter(fn: (r) => contains(value: r.device, set: ${device:json}))\n  |> last()"
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "type": "stat",
+      "title": "Current draw",
+      "datasource": { "type": "influxdb", "uid": "midea-influxdb" },
+      "gridPos": { "h": 4, "w": 6, "x": 6, "y": 0 },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "amp",
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "blue", "value": null },
+              { "color": "green", "value": 0.5 },
+              { "color": "orange", "value": 6 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": { "type": "influxdb", "uid": "midea-influxdb" },
+          "refId": "A",
+          "query": "from(bucket: \"${bucket}\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"midea\")\n  |> filter(fn: (r) => r._field == \"current_draw\")\n  |> filter(fn: (r) => contains(value: r.device, set: ${device:json}))\n  |> last()"
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "type": "stat",
+      "title": "Outdoor ambient temperature",
+      "datasource": { "type": "influxdb", "uid": "midea-influxdb" },
+      "gridPos": { "h": 4, "w": 6, "x": 12, "y": 0 },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "celsius",
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "blue", "value": null },
+              { "color": "green", "value": 10 },
+              { "color": "orange", "value": 35 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": { "type": "influxdb", "uid": "midea-influxdb" },
+          "refId": "A",
+          "query": "from(bucket: \"${bucket}\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"midea\")\n  |> filter(fn: (r) => r._field == \"outdoor_ambient_temperature\")\n  |> filter(fn: (r) => contains(value: r.device, set: ${device:json}))\n  |> last()"
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "type": "stat",
+      "title": "DC bus voltage",
+      "datasource": { "type": "influxdb", "uid": "midea-influxdb" },
+      "gridPos": { "h": 4, "w": 6, "x": 18, "y": 0 },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "volt",
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "blue", "value": null },
+              { "color": "green", "value": 200 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": { "type": "influxdb", "uid": "midea-influxdb" },
+          "refId": "A",
+          "query": "from(bucket: \"${bucket}\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"midea\")\n  |> filter(fn: (r) => r._field == \"dc_bus_voltage\")\n  |> filter(fn: (r) => contains(value: r.device, set: ${device:json}))\n  |> last()"
+        }
+      ]
+    },
+    {
+      "id": 10,
+      "type": "row",
+      "title": "Temperatures",
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 4 },
+      "panels": []
+    },
+    {
+      "id": 11,
+      "type": "timeseries",
+      "title": "Coil & ambient temperatures",
+      "datasource": { "type": "influxdb", "uid": "midea-influxdb" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 5 },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "celsius",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "fillOpacity": 5,
+            "showPoints": "never",
+            "spanNulls": true
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["last", "min", "max"] },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "influxdb", "uid": "midea-influxdb" },
+          "refId": "A",
+          "query": "from(bucket: \"${bucket}\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"midea\")\n  |> filter(fn: (r) => contains(value: r._field, set: [\"indoor_ambient_temperature\", \"indoor_coil_temperature\", \"outdoor_ambient_temperature\", \"outdoor_coil_temperature\"]))\n  |> filter(fn: (r) => contains(value: r.device, set: ${device:json}))\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)"
+        }
+      ]
+    },
+    {
+      "id": 12,
+      "type": "timeseries",
+      "title": "Discharge & IPM temperature",
+      "datasource": { "type": "influxdb", "uid": "midea-influxdb" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 5 },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "celsius",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "fillOpacity": 5,
+            "showPoints": "never",
+            "spanNulls": true
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["last", "min", "max"] },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "influxdb", "uid": "midea-influxdb" },
+          "refId": "A",
+          "query": "from(bucket: \"${bucket}\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"midea\")\n  |> filter(fn: (r) => contains(value: r._field, set: [\"discharge_temperature\", \"ipm_temperature\"]))\n  |> filter(fn: (r) => contains(value: r.device, set: ${device:json}))\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)"
+        }
+      ]
+    },
+    {
+      "id": 20,
+      "type": "row",
+      "title": "Compressor & refrigerant control",
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 13 },
+      "panels": []
+    },
+    {
+      "id": 21,
+      "type": "timeseries",
+      "title": "Compressor frequency (target vs actual)",
+      "datasource": { "type": "influxdb", "uid": "midea-influxdb" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 14 },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "hertz",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "stepAfter",
+            "lineWidth": 2,
+            "fillOpacity": 8,
+            "showPoints": "never",
+            "spanNulls": true
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["last", "max"] },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "influxdb", "uid": "midea-influxdb" },
+          "refId": "A",
+          "query": "from(bucket: \"${bucket}\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"midea\")\n  |> filter(fn: (r) => contains(value: r._field, set: [\"compressor_frequency_target\", \"compressor_frequency_actual\"]))\n  |> filter(fn: (r) => contains(value: r.device, set: ${device:json}))\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)"
+        }
+      ]
+    },
+    {
+      "id": 22,
+      "type": "timeseries",
+      "title": "Outdoor fan speed & EEV opening",
+      "datasource": { "type": "influxdb", "uid": "midea-influxdb" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 14 },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "stepAfter",
+            "lineWidth": 2,
+            "fillOpacity": 8,
+            "showPoints": "never",
+            "spanNulls": true
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["last", "max"] },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "influxdb", "uid": "midea-influxdb" },
+          "refId": "A",
+          "query": "from(bucket: \"${bucket}\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"midea\")\n  |> filter(fn: (r) => contains(value: r._field, set: [\"outdoor_fan_speed\", \"eev_steps\"]))\n  |> filter(fn: (r) => contains(value: r.device, set: ${device:json}))\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)"
+        }
+      ]
+    },
+    {
+      "id": 30,
+      "type": "row",
+      "title": "Electrical & setpoint",
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 22 },
+      "panels": []
+    },
+    {
+      "id": 31,
+      "type": "timeseries",
+      "title": "Input & DC bus voltage",
+      "datasource": { "type": "influxdb", "uid": "midea-influxdb" },
+      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 23 },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "volt",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "fillOpacity": 5,
+            "showPoints": "never",
+            "spanNulls": true
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom", "calcs": [] },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "influxdb", "uid": "midea-influxdb" },
+          "refId": "A",
+          "query": "from(bucket: \"${bucket}\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"midea\")\n  |> filter(fn: (r) => contains(value: r._field, set: [\"input_voltage\", \"dc_bus_voltage\"]))\n  |> filter(fn: (r) => contains(value: r.device, set: ${device:json}))\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)"
+        }
+      ]
+    },
+    {
+      "id": 32,
+      "type": "timeseries",
+      "title": "Current draw",
+      "datasource": { "type": "influxdb", "uid": "midea-influxdb" },
+      "gridPos": { "h": 8, "w": 8, "x": 8, "y": 23 },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "amp",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "spanNulls": true
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom", "calcs": [] },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "influxdb", "uid": "midea-influxdb" },
+          "refId": "A",
+          "query": "from(bucket: \"${bucket}\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"midea\")\n  |> filter(fn: (r) => r._field == \"current_draw\")\n  |> filter(fn: (r) => contains(value: r.device, set: ${device:json}))\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)"
+        }
+      ]
+    },
+    {
+      "id": 33,
+      "type": "timeseries",
+      "title": "Indoor set-point & operating mode",
+      "datasource": { "type": "influxdb", "uid": "midea-influxdb" },
+      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 23 },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "stepAfter",
+            "lineWidth": 2,
+            "fillOpacity": 0,
+            "showPoints": "never",
+            "spanNulls": true
+          }
+        },
+        "overrides": [
+          {
+            "matcher": { "id": "byFrameRefID", "options": "setpoint" },
+            "properties": [{ "id": "unit", "value": "celsius" }]
+          }
+        ]
+      },
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom", "calcs": [] },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "influxdb", "uid": "midea-influxdb" },
+          "refId": "setpoint",
+          "query": "from(bucket: \"${bucket}\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"midea\")\n  |> filter(fn: (r) => r._field == \"indoor_setpoint\")\n  |> filter(fn: (r) => contains(value: r.device, set: ${device:json}))\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)"
+        },
+        {
+          "datasource": { "type": "influxdb", "uid": "midea-influxdb" },
+          "refId": "mode",
+          "query": "from(bucket: \"${bucket}\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"midea\")\n  |> filter(fn: (r) => r._field == \"operating_mode\")\n  |> filter(fn: (r) => contains(value: r.device, set: ${device:json}))\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)"
+        }
+      ]
+    }
+  ]
+}

--- a/influxdb-grafana/grafana/provisioning/dashboards/dashboards.yml
+++ b/influxdb-grafana/grafana/provisioning/dashboards/dashboards.yml
@@ -1,0 +1,13 @@
+apiVersion: 1
+
+providers:
+  - name: midea-telemetry
+    orgId: 1
+    folder: Midea Telemetry
+    type: file
+    disableDeletion: false
+    updateIntervalSeconds: 30
+    allowUiUpdates: true
+    options:
+      path: /var/lib/grafana/dashboards
+      foldersFromFilesStructure: false

--- a/influxdb-grafana/grafana/provisioning/datasources/influxdb.yml
+++ b/influxdb-grafana/grafana/provisioning/datasources/influxdb.yml
@@ -1,0 +1,18 @@
+# Auto-provisioned InfluxDB v2 datasource (Flux). Values come from the env vars
+# passed to the Grafana container in docker-compose.yml.
+apiVersion: 1
+
+datasources:
+  - name: InfluxDB
+    type: influxdb
+    access: proxy
+    uid: midea-influxdb
+    url: http://influxdb:8086
+    isDefault: true
+    jsonData:
+      version: Flux
+      organization: ${INFLUX_ORG}
+      defaultBucket: ${INFLUX_BUCKET}
+      tlsSkipVerify: true
+    secureJsonData:
+      token: ${INFLUX_TOKEN}

--- a/influxdb-grafana/telegraf.conf
+++ b/influxdb-grafana/telegraf.conf
@@ -1,0 +1,59 @@
+# Telegraf: poll each midea-telemetry dongle's /json endpoint and write the
+# decoded sensor values to InfluxDB v2. Each dongle needs its own [[inputs.http]]
+# block so it can carry a distinct `device` tag.
+#
+# Requires the dongle firmware to be built with `expose_json_endpoint: true`.
+
+[agent]
+  interval = "10s"
+  round_interval = true
+  flush_interval = "10s"
+  omit_hostname = true
+
+[[outputs.influxdb_v2]]
+  urls = ["http://influxdb:8086"]
+  token = "${INFLUX_TOKEN}"
+  organization = "${INFLUX_ORG}"
+  bucket = "${INFLUX_BUCKET}"
+
+# ---------------------------------------------------------------------------
+# One block per dongle. Edit the URL and the `device` tag to match your setup.
+#
+# `json_query = "sensors"` selects the sensors sub-object; the classic JSON
+# parser then turns every numeric leaf into a field and silently ignores the
+# nulls the endpoint emits for stale/never-seen sensors.
+#
+# IMPORTANT: inside a bridged Docker container, ".local" (mDNS) names do NOT
+# resolve. Use the dongle's IP address here (e.g. http://192.168.1.42/json),
+# or enable host networking in docker-compose.yml on a Linux host.
+# ---------------------------------------------------------------------------
+
+[[inputs.http]]
+  urls = ["http://midea-telemetry-bedroom.local/json"]
+  method = "GET"
+  timeout = "5s"
+  name_override = "midea"
+  data_format = "json"
+  json_query = "sensors"
+  [inputs.http.tags]
+    device = "bedroom"
+
+[[inputs.http]]
+  urls = ["http://midea-telemetry-garage.local/json"]
+  method = "GET"
+  timeout = "5s"
+  name_override = "midea"
+  data_format = "json"
+  json_query = "sensors"
+  [inputs.http.tags]
+    device = "garage"
+
+[[inputs.http]]
+  urls = ["http://midea-telemetry-bathroom.local/json"]
+  method = "GET"
+  timeout = "5s"
+  name_override = "midea"
+  data_format = "json"
+  json_query = "sensors"
+  [inputs.http.tags]
+    device = "bathroom"


### PR DESCRIPTION
Self-contained Docker stack that polls each dongle's /json endpoint with Telegraf, stores decoded values in InfluxDB v2, and serves a provisioned Grafana dashboard on top. Independent of Home Assistant.