### PR TITLE
Add operating-mode card to Grafana dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,16 @@ T = 1 / (2.873×10⁻³ + 2.491×10⁻⁴ · L + 9.74×10⁻⁷ · L³) − 273.
 
 ³ Two OEM encodings, told apart by range (a real set-point is ~16–32 °C): whole-degree (16–32) or half-degree +50 (82–114).
 
-`operating_mode` is a raw integer code (e.g. `0` = cooling, `3` = fan). Map it to text in Home Assistant with a template sensor.
+`operating_mode` is a raw integer code:
+
+| Code | Mode | Code | Mode |
+|---|---|---|---|
+| 0 | Off | 4 | Dehumidify |
+| 1 | Cooling | 5 | Reserved |
+| 2 | Heating | 6 | Forced cool |
+| 3 | Fan only | 7 | Defrost |
+
+Map it to text in Home Assistant with a template sensor. The bundled [Grafana dashboard](influxdb-grafana/) already renders it as a labeled card plus a mode-history timeline.
 
 ## Compatibility
 

--- a/influxdb-grafana/grafana/dashboards/midea-telemetry.json
+++ b/influxdb-grafana/grafana/dashboards/midea-telemetry.json
@@ -501,7 +501,7 @@
       "type": "state-timeline",
       "title": "Operating Mode History",
       "datasource": { "type": "influxdb", "uid": "midea-influxdb" },
-      "gridPos": { "h": 6, "w": 18, "x": 6, "y": 28 },
+      "gridPos": { "h": 6, "w": 6, "x": 6, "y": 28 },
       "fieldConfig": {
         "defaults": {
           "decimals": 0,
@@ -543,7 +543,7 @@
       },
       "options": {
         "mergeValues": true,
-        "showValue": "auto",
+        "showValue": "never",
         "alignValue": "center",
         "rowHeight": 0.9,
         "legend": { "displayMode": "list", "placement": "bottom", "showLegend": false },

--- a/influxdb-grafana/grafana/dashboards/midea-telemetry.json
+++ b/influxdb-grafana/grafana/dashboards/midea-telemetry.json
@@ -447,33 +447,46 @@
         "defaults": {
           "decimals": 0,
           "color": { "mode": "thresholds" },
-          "thresholds": { "mode": "absolute", "steps": [ { "color": "text", "value": null } ] },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "#8e9099", "value": null },
+              { "color": "blue", "value": 1 },
+              { "color": "orange", "value": 2 },
+              { "color": "green", "value": 3 },
+              { "color": "purple", "value": 4 },
+              { "color": "#6e7079", "value": 5 },
+              { "color": "dark-blue", "value": 6 },
+              { "color": "light-blue", "value": 7 }
+            ]
+          },
           "mappings": [
             {
               "type": "value",
               "options": {
-                "0": { "text": "Off", "color": "#5c6670", "index": 0 },
-                "1": { "text": "Cooling", "color": "blue", "index": 1 },
-                "2": { "text": "Heating", "color": "orange", "index": 2 },
-                "3": { "text": "Fan only", "color": "green", "index": 3 },
-                "4": { "text": "Dehumidify", "color": "purple", "index": 4 },
-                "5": { "text": "Reserved", "color": "#3a3f4b", "index": 5 },
-                "6": { "text": "Forced cool", "color": "dark-blue", "index": 6 },
-                "7": { "text": "Defrost", "color": "light-blue", "index": 7 }
+                "0": { "text": "Off", "index": 0 },
+                "1": { "text": "Cooling", "index": 1 },
+                "2": { "text": "Heating", "index": 2 },
+                "3": { "text": "Fan only", "index": 3 },
+                "4": { "text": "Dehumidify", "index": 4 },
+                "5": { "text": "Reserved", "index": 5 },
+                "6": { "text": "Forced cool", "index": 6 },
+                "7": { "text": "Defrost", "index": 7 }
               }
             },
-            { "type": "special", "options": { "match": "null", "result": { "text": "—", "color": "#3a3f4b", "index": 8 } } }
+            { "type": "special", "options": { "match": "null", "result": { "text": "—", "index": 8 } } }
           ]
         },
         "overrides": []
       },
       "options": {
         "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
-        "colorMode": "background",
+        "colorMode": "value",
         "graphMode": "none",
         "justifyMode": "center",
         "textMode": "value",
-        "orientation": "auto"
+        "orientation": "auto",
+        "text": { "valueSize": 40 }
       },
       "targets": [
         {
@@ -493,23 +506,35 @@
         "defaults": {
           "decimals": 0,
           "color": { "mode": "thresholds" },
-          "thresholds": { "mode": "absolute", "steps": [ { "color": "text", "value": null } ] },
-          "custom": { "fillOpacity": 80, "lineWidth": 0 },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "#8e9099", "value": null },
+              { "color": "blue", "value": 1 },
+              { "color": "orange", "value": 2 },
+              { "color": "green", "value": 3 },
+              { "color": "purple", "value": 4 },
+              { "color": "#6e7079", "value": 5 },
+              { "color": "dark-blue", "value": 6 },
+              { "color": "light-blue", "value": 7 }
+            ]
+          },
+          "custom": { "fillOpacity": 70, "lineWidth": 0 },
           "mappings": [
             {
               "type": "value",
               "options": {
-                "0": { "text": "Off", "color": "#5c6670", "index": 0 },
-                "1": { "text": "Cooling", "color": "blue", "index": 1 },
-                "2": { "text": "Heating", "color": "orange", "index": 2 },
-                "3": { "text": "Fan only", "color": "green", "index": 3 },
-                "4": { "text": "Dehumidify", "color": "purple", "index": 4 },
-                "5": { "text": "Reserved", "color": "#3a3f4b", "index": 5 },
-                "6": { "text": "Forced cool", "color": "dark-blue", "index": 6 },
-                "7": { "text": "Defrost", "color": "light-blue", "index": 7 }
+                "0": { "text": "Off", "index": 0 },
+                "1": { "text": "Cooling", "index": 1 },
+                "2": { "text": "Heating", "index": 2 },
+                "3": { "text": "Fan only", "index": 3 },
+                "4": { "text": "Dehumidify", "index": 4 },
+                "5": { "text": "Reserved", "index": 5 },
+                "6": { "text": "Forced cool", "index": 6 },
+                "7": { "text": "Defrost", "index": 7 }
               }
             },
-            { "type": "special", "options": { "match": "null", "result": { "text": "—", "color": "#3a3f4b", "index": 8 } } }
+            { "type": "special", "options": { "match": "null", "result": { "text": "—", "index": 8 } } }
           ]
         },
         "overrides": [
@@ -521,7 +546,7 @@
         "showValue": "auto",
         "alignValue": "center",
         "rowHeight": 0.9,
-        "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true },
+        "legend": { "displayMode": "list", "placement": "bottom", "showLegend": false },
         "tooltip": { "mode": "single", "sort": "none" }
       },
       "targets": [

--- a/influxdb-grafana/grafana/dashboards/midea-telemetry.json
+++ b/influxdb-grafana/grafana/dashboards/midea-telemetry.json
@@ -58,28 +58,28 @@
       "id": 100,
       "type": "text",
       "transparent": true,
-      "gridPos": { "h": 2, "w": 6, "x": 0, "y": 0 },
+      "gridPos": { "h": 2, "w": 6, "x": 0, "y": 8 },
       "options": { "mode": "markdown", "content": "### IDU" }
     },
     {
       "id": 101,
       "type": "text",
       "transparent": true,
-      "gridPos": { "h": 2, "w": 6, "x": 6, "y": 0 },
+      "gridPos": { "h": 2, "w": 6, "x": 6, "y": 8 },
       "options": { "mode": "markdown", "content": "### ODU" }
     },
     {
       "id": 102,
       "type": "text",
       "transparent": true,
-      "gridPos": { "h": 2, "w": 6, "x": 12, "y": 0 },
+      "gridPos": { "h": 2, "w": 6, "x": 12, "y": 8 },
       "options": { "mode": "markdown", "content": "### Compressor / EEV" }
     },
     {
       "id": 103,
       "type": "text",
       "transparent": true,
-      "gridPos": { "h": 2, "w": 6, "x": 18, "y": 0 },
+      "gridPos": { "h": 2, "w": 6, "x": 18, "y": 8 },
       "options": { "mode": "markdown", "content": "### Fan + Power" }
     },
 
@@ -88,7 +88,7 @@
       "type": "timeseries",
       "title": "Indoor Temperature",
       "datasource": { "type": "influxdb", "uid": "midea-influxdb" },
-      "gridPos": { "h": 8, "w": 6, "x": 0, "y": 2 },
+      "gridPos": { "h": 8, "w": 6, "x": 0, "y": 10 },
       "fieldConfig": {
         "defaults": {
           "unit": "fahrenheit",
@@ -115,7 +115,7 @@
       "type": "timeseries",
       "title": "Outdoor Temperature",
       "datasource": { "type": "influxdb", "uid": "midea-influxdb" },
-      "gridPos": { "h": 8, "w": 6, "x": 0, "y": 10 },
+      "gridPos": { "h": 8, "w": 6, "x": 0, "y": 18 },
       "fieldConfig": {
         "defaults": {
           "unit": "fahrenheit",
@@ -142,7 +142,7 @@
       "type": "timeseries",
       "title": "Set Point",
       "datasource": { "type": "influxdb", "uid": "midea-influxdb" },
-      "gridPos": { "h": 8, "w": 6, "x": 0, "y": 18 },
+      "gridPos": { "h": 8, "w": 6, "x": 0, "y": 26 },
       "fieldConfig": {
         "defaults": {
           "unit": "fahrenheit",
@@ -170,7 +170,7 @@
       "type": "timeseries",
       "title": "Indoor Coil Temperature",
       "datasource": { "type": "influxdb", "uid": "midea-influxdb" },
-      "gridPos": { "h": 8, "w": 6, "x": 6, "y": 2 },
+      "gridPos": { "h": 8, "w": 6, "x": 6, "y": 10 },
       "fieldConfig": {
         "defaults": {
           "unit": "fahrenheit",
@@ -197,7 +197,7 @@
       "type": "timeseries",
       "title": "Outdoor Coil Temperature",
       "datasource": { "type": "influxdb", "uid": "midea-influxdb" },
-      "gridPos": { "h": 8, "w": 6, "x": 6, "y": 10 },
+      "gridPos": { "h": 8, "w": 6, "x": 6, "y": 18 },
       "fieldConfig": {
         "defaults": {
           "unit": "fahrenheit",
@@ -224,7 +224,7 @@
       "type": "timeseries",
       "title": "Compressor Discharge Temperature",
       "datasource": { "type": "influxdb", "uid": "midea-influxdb" },
-      "gridPos": { "h": 8, "w": 6, "x": 6, "y": 18 },
+      "gridPos": { "h": 8, "w": 6, "x": 6, "y": 26 },
       "fieldConfig": {
         "defaults": {
           "unit": "fahrenheit",
@@ -252,7 +252,7 @@
       "type": "timeseries",
       "title": "Compressor Frequency (actual)",
       "datasource": { "type": "influxdb", "uid": "midea-influxdb" },
-      "gridPos": { "h": 8, "w": 6, "x": 12, "y": 2 },
+      "gridPos": { "h": 8, "w": 6, "x": 12, "y": 10 },
       "fieldConfig": {
         "defaults": {
           "unit": "suffix:Hz",
@@ -279,7 +279,7 @@
       "type": "timeseries",
       "title": "Compressor Frequency (target)",
       "datasource": { "type": "influxdb", "uid": "midea-influxdb" },
-      "gridPos": { "h": 8, "w": 6, "x": 12, "y": 10 },
+      "gridPos": { "h": 8, "w": 6, "x": 12, "y": 18 },
       "fieldConfig": {
         "defaults": {
           "unit": "suffix:Hz",
@@ -306,7 +306,7 @@
       "type": "timeseries",
       "title": "EEV Opening Steps",
       "datasource": { "type": "influxdb", "uid": "midea-influxdb" },
-      "gridPos": { "h": 8, "w": 6, "x": 12, "y": 18 },
+      "gridPos": { "h": 8, "w": 6, "x": 12, "y": 26 },
       "fieldConfig": {
         "defaults": {
           "unit": "short",
@@ -334,7 +334,7 @@
       "type": "timeseries",
       "title": "Outdoor fan speed",
       "datasource": { "type": "influxdb", "uid": "midea-influxdb" },
-      "gridPos": { "h": 8, "w": 6, "x": 18, "y": 2 },
+      "gridPos": { "h": 8, "w": 6, "x": 18, "y": 10 },
       "fieldConfig": {
         "defaults": {
           "unit": "short",
@@ -361,7 +361,7 @@
       "type": "timeseries",
       "title": "Current Draw",
       "datasource": { "type": "influxdb", "uid": "midea-influxdb" },
-      "gridPos": { "h": 8, "w": 6, "x": 18, "y": 10 },
+      "gridPos": { "h": 8, "w": 6, "x": 18, "y": 18 },
       "fieldConfig": {
         "defaults": {
           "unit": "amp",
@@ -388,7 +388,7 @@
       "type": "timeseries",
       "title": "AC / DC Bus Voltage",
       "datasource": { "type": "influxdb", "uid": "midea-influxdb" },
-      "gridPos": { "h": 8, "w": 6, "x": 18, "y": 18 },
+      "gridPos": { "h": 8, "w": 6, "x": 18, "y": 26 },
       "fieldConfig": {
         "defaults": {
           "unit": "volt",
@@ -434,7 +434,7 @@
       "id": 200,
       "type": "text",
       "transparent": true,
-      "gridPos": { "h": 2, "w": 24, "x": 0, "y": 26 },
+      "gridPos": { "h": 2, "w": 24, "x": 0, "y": 0 },
       "options": { "mode": "markdown", "content": "### Operating Mode" }
     },
     {
@@ -442,7 +442,7 @@
       "type": "stat",
       "title": "Operating Mode",
       "datasource": { "type": "influxdb", "uid": "midea-influxdb" },
-      "gridPos": { "h": 6, "w": 6, "x": 0, "y": 28 },
+      "gridPos": { "h": 6, "w": 6, "x": 0, "y": 2 },
       "fieldConfig": {
         "defaults": {
           "decimals": 0,
@@ -501,7 +501,7 @@
       "type": "state-timeline",
       "title": "Operating Mode History",
       "datasource": { "type": "influxdb", "uid": "midea-influxdb" },
-      "gridPos": { "h": 6, "w": 6, "x": 6, "y": 28 },
+      "gridPos": { "h": 6, "w": 6, "x": 6, "y": 2 },
       "fieldConfig": {
         "defaults": {
           "decimals": 0,

--- a/influxdb-grafana/grafana/dashboards/midea-telemetry.json
+++ b/influxdb-grafana/grafana/dashboards/midea-telemetry.json
@@ -58,28 +58,28 @@
       "id": 100,
       "type": "text",
       "transparent": true,
-      "gridPos": { "h": 2, "w": 6, "x": 0, "y": 8 },
+      "gridPos": { "h": 2, "w": 6, "x": 0, "y": 6 },
       "options": { "mode": "markdown", "content": "### IDU" }
     },
     {
       "id": 101,
       "type": "text",
       "transparent": true,
-      "gridPos": { "h": 2, "w": 6, "x": 6, "y": 8 },
+      "gridPos": { "h": 2, "w": 6, "x": 6, "y": 6 },
       "options": { "mode": "markdown", "content": "### ODU" }
     },
     {
       "id": 102,
       "type": "text",
       "transparent": true,
-      "gridPos": { "h": 2, "w": 6, "x": 12, "y": 8 },
+      "gridPos": { "h": 2, "w": 6, "x": 12, "y": 6 },
       "options": { "mode": "markdown", "content": "### Compressor / EEV" }
     },
     {
       "id": 103,
       "type": "text",
       "transparent": true,
-      "gridPos": { "h": 2, "w": 6, "x": 18, "y": 8 },
+      "gridPos": { "h": 2, "w": 6, "x": 18, "y": 6 },
       "options": { "mode": "markdown", "content": "### Fan + Power" }
     },
 
@@ -88,7 +88,7 @@
       "type": "timeseries",
       "title": "Indoor Temperature",
       "datasource": { "type": "influxdb", "uid": "midea-influxdb" },
-      "gridPos": { "h": 8, "w": 6, "x": 0, "y": 10 },
+      "gridPos": { "h": 8, "w": 6, "x": 0, "y": 8 },
       "fieldConfig": {
         "defaults": {
           "unit": "fahrenheit",
@@ -115,7 +115,7 @@
       "type": "timeseries",
       "title": "Outdoor Temperature",
       "datasource": { "type": "influxdb", "uid": "midea-influxdb" },
-      "gridPos": { "h": 8, "w": 6, "x": 0, "y": 18 },
+      "gridPos": { "h": 8, "w": 6, "x": 0, "y": 16 },
       "fieldConfig": {
         "defaults": {
           "unit": "fahrenheit",
@@ -142,7 +142,7 @@
       "type": "timeseries",
       "title": "Set Point",
       "datasource": { "type": "influxdb", "uid": "midea-influxdb" },
-      "gridPos": { "h": 8, "w": 6, "x": 0, "y": 26 },
+      "gridPos": { "h": 8, "w": 6, "x": 0, "y": 24 },
       "fieldConfig": {
         "defaults": {
           "unit": "fahrenheit",
@@ -170,7 +170,7 @@
       "type": "timeseries",
       "title": "Indoor Coil Temperature",
       "datasource": { "type": "influxdb", "uid": "midea-influxdb" },
-      "gridPos": { "h": 8, "w": 6, "x": 6, "y": 10 },
+      "gridPos": { "h": 8, "w": 6, "x": 6, "y": 8 },
       "fieldConfig": {
         "defaults": {
           "unit": "fahrenheit",
@@ -197,7 +197,7 @@
       "type": "timeseries",
       "title": "Outdoor Coil Temperature",
       "datasource": { "type": "influxdb", "uid": "midea-influxdb" },
-      "gridPos": { "h": 8, "w": 6, "x": 6, "y": 18 },
+      "gridPos": { "h": 8, "w": 6, "x": 6, "y": 16 },
       "fieldConfig": {
         "defaults": {
           "unit": "fahrenheit",
@@ -224,7 +224,7 @@
       "type": "timeseries",
       "title": "Compressor Discharge Temperature",
       "datasource": { "type": "influxdb", "uid": "midea-influxdb" },
-      "gridPos": { "h": 8, "w": 6, "x": 6, "y": 26 },
+      "gridPos": { "h": 8, "w": 6, "x": 6, "y": 24 },
       "fieldConfig": {
         "defaults": {
           "unit": "fahrenheit",
@@ -252,7 +252,7 @@
       "type": "timeseries",
       "title": "Compressor Frequency (actual)",
       "datasource": { "type": "influxdb", "uid": "midea-influxdb" },
-      "gridPos": { "h": 8, "w": 6, "x": 12, "y": 10 },
+      "gridPos": { "h": 8, "w": 6, "x": 12, "y": 8 },
       "fieldConfig": {
         "defaults": {
           "unit": "suffix:Hz",
@@ -279,7 +279,7 @@
       "type": "timeseries",
       "title": "Compressor Frequency (target)",
       "datasource": { "type": "influxdb", "uid": "midea-influxdb" },
-      "gridPos": { "h": 8, "w": 6, "x": 12, "y": 18 },
+      "gridPos": { "h": 8, "w": 6, "x": 12, "y": 16 },
       "fieldConfig": {
         "defaults": {
           "unit": "suffix:Hz",
@@ -306,7 +306,7 @@
       "type": "timeseries",
       "title": "EEV Opening Steps",
       "datasource": { "type": "influxdb", "uid": "midea-influxdb" },
-      "gridPos": { "h": 8, "w": 6, "x": 12, "y": 26 },
+      "gridPos": { "h": 8, "w": 6, "x": 12, "y": 24 },
       "fieldConfig": {
         "defaults": {
           "unit": "short",
@@ -334,7 +334,7 @@
       "type": "timeseries",
       "title": "Outdoor fan speed",
       "datasource": { "type": "influxdb", "uid": "midea-influxdb" },
-      "gridPos": { "h": 8, "w": 6, "x": 18, "y": 10 },
+      "gridPos": { "h": 8, "w": 6, "x": 18, "y": 8 },
       "fieldConfig": {
         "defaults": {
           "unit": "short",
@@ -361,7 +361,7 @@
       "type": "timeseries",
       "title": "Current Draw",
       "datasource": { "type": "influxdb", "uid": "midea-influxdb" },
-      "gridPos": { "h": 8, "w": 6, "x": 18, "y": 18 },
+      "gridPos": { "h": 8, "w": 6, "x": 18, "y": 16 },
       "fieldConfig": {
         "defaults": {
           "unit": "amp",
@@ -388,7 +388,7 @@
       "type": "timeseries",
       "title": "AC / DC Bus Voltage",
       "datasource": { "type": "influxdb", "uid": "midea-influxdb" },
-      "gridPos": { "h": 8, "w": 6, "x": 18, "y": 26 },
+      "gridPos": { "h": 8, "w": 6, "x": 18, "y": 24 },
       "fieldConfig": {
         "defaults": {
           "unit": "volt",
@@ -429,20 +429,12 @@
         }
       ]
     },
-
-    {
-      "id": 200,
-      "type": "text",
-      "transparent": true,
-      "gridPos": { "h": 2, "w": 24, "x": 0, "y": 0 },
-      "options": { "mode": "markdown", "content": "### Operating Mode" }
-    },
     {
       "id": 13,
       "type": "stat",
       "title": "Operating Mode",
       "datasource": { "type": "influxdb", "uid": "midea-influxdb" },
-      "gridPos": { "h": 6, "w": 6, "x": 0, "y": 2 },
+      "gridPos": { "h": 6, "w": 6, "x": 0, "y": 0 },
       "fieldConfig": {
         "defaults": {
           "decimals": 0,
@@ -501,7 +493,7 @@
       "type": "state-timeline",
       "title": "Operating Mode History",
       "datasource": { "type": "influxdb", "uid": "midea-influxdb" },
-      "gridPos": { "h": 6, "w": 6, "x": 6, "y": 2 },
+      "gridPos": { "h": 6, "w": 6, "x": 6, "y": 0 },
       "fieldConfig": {
         "defaults": {
           "decimals": 0,

--- a/influxdb-grafana/grafana/dashboards/midea-telemetry.json
+++ b/influxdb-grafana/grafana/dashboards/midea-telemetry.json
@@ -548,6 +548,13 @@
           "query": "from(bucket: \"${bucket}\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"midea\")\n  |> filter(fn: (r) => r._field == \"operating_mode\")\n  |> filter(fn: (r) => r.device == \"${device}\")\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)"
         }
       ]
+    },
+    {
+      "id": 201,
+      "type": "text",
+      "transparent": true,
+      "gridPos": { "h": 6, "w": 12, "x": 12, "y": 0 },
+      "options": { "mode": "markdown", "content": "" }
     }
   ]
 }

--- a/influxdb-grafana/grafana/dashboards/midea-telemetry.json
+++ b/influxdb-grafana/grafana/dashboards/midea-telemetry.json
@@ -55,40 +55,11 @@
   "weekStart": "",
   "panels": [
     {
-      "id": 100,
-      "type": "text",
-      "transparent": true,
-      "gridPos": { "h": 2, "w": 6, "x": 0, "y": 6 },
-      "options": { "mode": "markdown", "content": "### IDU" }
-    },
-    {
-      "id": 101,
-      "type": "text",
-      "transparent": true,
-      "gridPos": { "h": 2, "w": 6, "x": 6, "y": 6 },
-      "options": { "mode": "markdown", "content": "### ODU" }
-    },
-    {
-      "id": 102,
-      "type": "text",
-      "transparent": true,
-      "gridPos": { "h": 2, "w": 6, "x": 12, "y": 6 },
-      "options": { "mode": "markdown", "content": "### Compressor / EEV" }
-    },
-    {
-      "id": 103,
-      "type": "text",
-      "transparent": true,
-      "gridPos": { "h": 2, "w": 6, "x": 18, "y": 6 },
-      "options": { "mode": "markdown", "content": "### Fan + Power" }
-    },
-
-    {
       "id": 1,
       "type": "timeseries",
       "title": "Indoor Temperature",
       "datasource": { "type": "influxdb", "uid": "midea-influxdb" },
-      "gridPos": { "h": 8, "w": 6, "x": 0, "y": 8 },
+      "gridPos": { "h": 8, "w": 6, "x": 0, "y": 6 },
       "fieldConfig": {
         "defaults": {
           "unit": "fahrenheit",
@@ -115,7 +86,7 @@
       "type": "timeseries",
       "title": "Outdoor Temperature",
       "datasource": { "type": "influxdb", "uid": "midea-influxdb" },
-      "gridPos": { "h": 8, "w": 6, "x": 0, "y": 16 },
+      "gridPos": { "h": 8, "w": 6, "x": 0, "y": 14 },
       "fieldConfig": {
         "defaults": {
           "unit": "fahrenheit",
@@ -142,7 +113,7 @@
       "type": "timeseries",
       "title": "Set Point",
       "datasource": { "type": "influxdb", "uid": "midea-influxdb" },
-      "gridPos": { "h": 8, "w": 6, "x": 0, "y": 24 },
+      "gridPos": { "h": 8, "w": 6, "x": 0, "y": 22 },
       "fieldConfig": {
         "defaults": {
           "unit": "fahrenheit",
@@ -170,7 +141,7 @@
       "type": "timeseries",
       "title": "Indoor Coil Temperature",
       "datasource": { "type": "influxdb", "uid": "midea-influxdb" },
-      "gridPos": { "h": 8, "w": 6, "x": 6, "y": 8 },
+      "gridPos": { "h": 8, "w": 6, "x": 6, "y": 6 },
       "fieldConfig": {
         "defaults": {
           "unit": "fahrenheit",
@@ -197,7 +168,7 @@
       "type": "timeseries",
       "title": "Outdoor Coil Temperature",
       "datasource": { "type": "influxdb", "uid": "midea-influxdb" },
-      "gridPos": { "h": 8, "w": 6, "x": 6, "y": 16 },
+      "gridPos": { "h": 8, "w": 6, "x": 6, "y": 14 },
       "fieldConfig": {
         "defaults": {
           "unit": "fahrenheit",
@@ -224,7 +195,7 @@
       "type": "timeseries",
       "title": "Compressor Discharge Temperature",
       "datasource": { "type": "influxdb", "uid": "midea-influxdb" },
-      "gridPos": { "h": 8, "w": 6, "x": 6, "y": 24 },
+      "gridPos": { "h": 8, "w": 6, "x": 6, "y": 22 },
       "fieldConfig": {
         "defaults": {
           "unit": "fahrenheit",
@@ -252,7 +223,7 @@
       "type": "timeseries",
       "title": "Compressor Frequency (actual)",
       "datasource": { "type": "influxdb", "uid": "midea-influxdb" },
-      "gridPos": { "h": 8, "w": 6, "x": 12, "y": 8 },
+      "gridPos": { "h": 8, "w": 6, "x": 12, "y": 6 },
       "fieldConfig": {
         "defaults": {
           "unit": "suffix:Hz",
@@ -279,7 +250,7 @@
       "type": "timeseries",
       "title": "Compressor Frequency (target)",
       "datasource": { "type": "influxdb", "uid": "midea-influxdb" },
-      "gridPos": { "h": 8, "w": 6, "x": 12, "y": 16 },
+      "gridPos": { "h": 8, "w": 6, "x": 12, "y": 14 },
       "fieldConfig": {
         "defaults": {
           "unit": "suffix:Hz",
@@ -306,7 +277,7 @@
       "type": "timeseries",
       "title": "EEV Opening Steps",
       "datasource": { "type": "influxdb", "uid": "midea-influxdb" },
-      "gridPos": { "h": 8, "w": 6, "x": 12, "y": 24 },
+      "gridPos": { "h": 8, "w": 6, "x": 12, "y": 22 },
       "fieldConfig": {
         "defaults": {
           "unit": "short",
@@ -334,7 +305,7 @@
       "type": "timeseries",
       "title": "Outdoor fan speed",
       "datasource": { "type": "influxdb", "uid": "midea-influxdb" },
-      "gridPos": { "h": 8, "w": 6, "x": 18, "y": 8 },
+      "gridPos": { "h": 8, "w": 6, "x": 18, "y": 6 },
       "fieldConfig": {
         "defaults": {
           "unit": "short",
@@ -361,7 +332,7 @@
       "type": "timeseries",
       "title": "Current Draw",
       "datasource": { "type": "influxdb", "uid": "midea-influxdb" },
-      "gridPos": { "h": 8, "w": 6, "x": 18, "y": 16 },
+      "gridPos": { "h": 8, "w": 6, "x": 18, "y": 14 },
       "fieldConfig": {
         "defaults": {
           "unit": "amp",
@@ -388,7 +359,7 @@
       "type": "timeseries",
       "title": "AC / DC Bus Voltage",
       "datasource": { "type": "influxdb", "uid": "midea-influxdb" },
-      "gridPos": { "h": 8, "w": 6, "x": 18, "y": 24 },
+      "gridPos": { "h": 8, "w": 6, "x": 18, "y": 22 },
       "fieldConfig": {
         "defaults": {
           "unit": "volt",

--- a/influxdb-grafana/grafana/dashboards/midea-telemetry.json
+++ b/influxdb-grafana/grafana/dashboards/midea-telemetry.json
@@ -428,6 +428,109 @@
           "query": "from(bucket: \"${bucket}\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"midea\")\n  |> filter(fn: (r) => r._field == \"dc_bus_voltage\")\n  |> filter(fn: (r) => r.device == \"${device}\")\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)"
         }
       ]
+    },
+
+    {
+      "id": 200,
+      "type": "text",
+      "transparent": true,
+      "gridPos": { "h": 2, "w": 24, "x": 0, "y": 26 },
+      "options": { "mode": "markdown", "content": "### Operating Mode" }
+    },
+    {
+      "id": 13,
+      "type": "stat",
+      "title": "Operating Mode",
+      "datasource": { "type": "influxdb", "uid": "midea-influxdb" },
+      "gridPos": { "h": 6, "w": 6, "x": 0, "y": 28 },
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 0,
+          "color": { "mode": "thresholds" },
+          "thresholds": { "mode": "absolute", "steps": [ { "color": "text", "value": null } ] },
+          "mappings": [
+            {
+              "type": "value",
+              "options": {
+                "0": { "text": "Off", "color": "#5c6670", "index": 0 },
+                "1": { "text": "Cooling", "color": "blue", "index": 1 },
+                "2": { "text": "Heating", "color": "orange", "index": 2 },
+                "3": { "text": "Fan only", "color": "green", "index": 3 },
+                "4": { "text": "Dehumidify", "color": "purple", "index": 4 },
+                "5": { "text": "Reserved", "color": "#3a3f4b", "index": 5 },
+                "6": { "text": "Forced cool", "color": "dark-blue", "index": 6 },
+                "7": { "text": "Defrost", "color": "light-blue", "index": 7 }
+              }
+            },
+            { "type": "special", "options": { "match": "null", "result": { "text": "—", "color": "#3a3f4b", "index": 8 } } }
+          ]
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "textMode": "value",
+        "orientation": "auto"
+      },
+      "targets": [
+        {
+          "datasource": { "type": "influxdb", "uid": "midea-influxdb" },
+          "refId": "A",
+          "query": "from(bucket: \"${bucket}\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"midea\")\n  |> filter(fn: (r) => r._field == \"operating_mode\")\n  |> filter(fn: (r) => r.device == \"${device}\")\n  |> last()"
+        }
+      ]
+    },
+    {
+      "id": 14,
+      "type": "state-timeline",
+      "title": "Operating Mode History",
+      "datasource": { "type": "influxdb", "uid": "midea-influxdb" },
+      "gridPos": { "h": 6, "w": 18, "x": 6, "y": 28 },
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 0,
+          "color": { "mode": "thresholds" },
+          "thresholds": { "mode": "absolute", "steps": [ { "color": "text", "value": null } ] },
+          "custom": { "fillOpacity": 80, "lineWidth": 0 },
+          "mappings": [
+            {
+              "type": "value",
+              "options": {
+                "0": { "text": "Off", "color": "#5c6670", "index": 0 },
+                "1": { "text": "Cooling", "color": "blue", "index": 1 },
+                "2": { "text": "Heating", "color": "orange", "index": 2 },
+                "3": { "text": "Fan only", "color": "green", "index": 3 },
+                "4": { "text": "Dehumidify", "color": "purple", "index": 4 },
+                "5": { "text": "Reserved", "color": "#3a3f4b", "index": 5 },
+                "6": { "text": "Forced cool", "color": "dark-blue", "index": 6 },
+                "7": { "text": "Defrost", "color": "light-blue", "index": 7 }
+              }
+            },
+            { "type": "special", "options": { "match": "null", "result": { "text": "—", "color": "#3a3f4b", "index": 8 } } }
+          ]
+        },
+        "overrides": [
+          { "matcher": { "id": "byFrameRefID", "options": "A" }, "properties": [ { "id": "displayName", "value": "Mode" } ] }
+        ]
+      },
+      "options": {
+        "mergeValues": true,
+        "showValue": "auto",
+        "alignValue": "center",
+        "rowHeight": 0.9,
+        "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "single", "sort": "none" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "influxdb", "uid": "midea-influxdb" },
+          "refId": "A",
+          "query": "from(bucket: \"${bucket}\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"midea\")\n  |> filter(fn: (r) => r._field == \"operating_mode\")\n  |> filter(fn: (r) => r.device == \"${device}\")\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
Adds an "Operating Mode" section to the bundled Grafana dashboard: a stat card showing the current mode as a colored, labeled value (the analog of the Home Assistant mode card), plus a state-timeline showing mode history over the selected range. Both decode the raw operating_mode integer via shared value mappings (0=Off, 1=Cooling, 2=Heating, 3=Fan only, 4=Dehumidify, 5=Reserved, 6=Forced cool, 7=Defrost).

Also corrects the operating_mode code documentation in the README, which previously mislabeled 0 as cooling (0 is Off; 1 is Cooling).

Closes #25