### PR TITLE
Gate current_draw on compressor state (#16)

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ Byte mapping and conversion formulas as documented in [Reverse Engineering Midea
 | `eev_steps` | raw | 1 | 5+6 | `b₅ \| b₆ << 8` (uint16 LE) |
 | `indoor_setpoint` | °C | 1 | 7 | `b < 50 ? b : (b − 50) / 2` ³ |
 | `input_voltage` | V | 1 | 3 | `⌊b · 32/25 + 40⌋` |
-| `current_draw` | A | 1 | 2 | `0.117 · b + 0.92` |
+| `current_draw` | A | 1 | 2 | `0.117 · b + 0.92` ⁴ |
 | `dc_bus_voltage` | V | 3 | 6 | `round(b · 59/32 − 1)` |
 
 Where `b` is the raw byte value.
@@ -202,6 +202,8 @@ T = 1 / (2.873×10⁻³ + 2.491×10⁻⁴ · L + 9.74×10⁻⁷ · L³) − 273.
 ```
 
 ³ Two OEM encodings, told apart by range (a real set-point is ~16–32 °C): whole-degree (16–32) or half-degree +50 (82–114).
+
+⁴ The byte only carries a meaningful current while the compressor runs. When it is stopped (unit OFF or FAN ONLY) the byte sits at a per-unit floor (3 on the 115V MRCOOL, 0 on the 220V Cooper & Hunter) that the formula would misread as ~1 A, so `current_draw` reports the ~0.2 A standby baseline measured with a clamp meter whenever `compressor_frequency_actual` (response 2, byte 3) is 0.
 
 `operating_mode` is a raw integer code:
 

--- a/components/midea_telemetry/midea_telemetry.cpp
+++ b/components/midea_telemetry/midea_telemetry.cpp
@@ -54,7 +54,17 @@ static float discharge_temp(uint8_t v) {
 
 static float ac_voltage(uint8_t v) { return truncf(v * 32.0f / 25.0f + 40.0f); }
 
-static float current_draw(uint8_t v) { return truncf((0.117f * v + 0.92f) * 100.0f) / 100.0f; }
+// Compressor current. The 0x01[2] byte only carries a meaningful reading while
+// the compressor runs; when it is off (unit OFF or FAN ONLY) the byte sits at a
+// per-unit floor (3 on the 115V MRCOOL, 0 on the 220V Cooper & Hunter) that the
+// linear model would misdecode as ~1 A. Gate on the actual compressor frequency
+// and report the ~0.2 A standby baseline a Fluke 325 clamp meter measured in
+// that state instead (issue #16).
+static float current_draw(uint8_t v, uint8_t compressor_freq) {
+  if (compressor_freq == 0)
+    return 0.2f;
+  return truncf((0.117f * v + 0.92f) * 100.0f) / 100.0f;
+}
 
 // DC bus (inverter DC-link) voltage.
 static float dc_bus_voltage(uint8_t v) { return roundf(v * 59.0f / 32.0f - 1.0f); }
@@ -114,7 +124,7 @@ static const MappedParam MAPPED_PARAMS[] = {
     {"eev_steps",                    0x01, {5, 6}, 2, [](const uint8_t f[][FRAME_SIZE]) { return uint16(f[0x01][5], f[0x01][6]); }},
     {"indoor_setpoint",              0x01, {7},    1, [](const uint8_t f[][FRAME_SIZE]) { return indoor_setpoint(f[0x01][7]); }},
     {"input_voltage",                0x01, {3},    1, [](const uint8_t f[][FRAME_SIZE]) { return ac_voltage(f[0x01][3]); }},
-    {"current_draw",                 0x01, {2},    1, [](const uint8_t f[][FRAME_SIZE]) { return current_draw(f[0x01][2]); }},
+    {"current_draw",                 0x01, {2},    1, [](const uint8_t f[][FRAME_SIZE]) { return current_draw(f[0x01][2], f[0x02][3]); }},
     {"dc_bus_voltage",               0x03, {6},    1, [](const uint8_t f[][FRAME_SIZE]) { return dc_bus_voltage(f[0x03][6]); }},
 };
 // clang-format on


### PR DESCRIPTION
The 0x01[2] byte only carries a meaningful current reading while the compressor runs. When the unit is OFF or in FAN ONLY mode the byte sits at a per-unit floor (3 on the 115V MRCOOL, 0 on the 220V Cooper & Hunter) that the linear model misdecodes as ~1 A, when a Fluke 325 clamp meter shows only ~0.2 A.

Gate current_draw on the actual compressor frequency (0x02[3]): report the measured 0.2 A standby baseline when the compressor is stopped, otherwise apply the linear decode as before. Gating on frequency rather than the byte value handles both units, whose floor bytes differ.