### PR TITLE
Revise compressor frequency mappings (issue #34)

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,11 @@ The following sensors are currently supported:
 | `discharge_temperature` | °C | 0x00[6] | Steinhart–Hart ² |
 | `ipm_temperature` | °C | 0x01[4] | NTC β-model ¹ |
 | `operating_mode` | raw | 0x02[8] | `b` |
-| `compressor_frequency_target` | Hz | 0x02[2] | `b` |
-| `compressor_frequency_actual` | Hz | 0x02[3] | `b` |
+| `compressor_frequency_indoor_target` | Hz | 0x04[8] | `b` ⁵ |
+| `compressor_frequency_outdoor_target` | Hz | 0x02[2] | `b` |
+| `compressor_frequency_actual_int` | Hz | 0x02[3] | `b` |
+| `compressor_frequency_actual_float` | Hz | 0x02[3] + 0x05[2] | `b₀₂₋₃ + b₀₅₋₂ / 100` ⁵ |
+| `compressor_frequency_outdoor_control` | Hz | 0x04[7] | `b` ⁵ |
 | `outdoor_fan_speed` | raw | 0x00[7+8] | `b₇ \| b₈ << 8` (uint16 LE) |
 | `eev_steps` | raw | 0x01[5+6] | `b₅ \| b₆ << 8` (uint16 LE) |
 | `indoor_setpoint` | °C | 0x01[7] | `b < 50 ? b : (b − 50) / 2` ³ |
@@ -43,7 +46,9 @@ T = 1 / (2.873×10⁻³ + 2.491×10⁻⁴ · L + 9.74×10⁻⁷ · L³) − 273.
 
 ³ Two OEM encodings, told apart by range (a real set-point is ~16–32 °C): whole-degree (16–32) or half-degree +50 (82–114).
 
-⁴ The byte only carries a meaningful current while the compressor runs. When it is stopped (unit OFF or FAN ONLY) the byte sits at a per-unit floor (3 on the 115V MRCOOL, 0 on the 220V Cooper & Hunter) that the formula would misread as ~1 A, so `current_draw` reports the ~0.2 A standby baseline measured with a clamp meter whenever `compressor_frequency_actual` (response 2, byte 3) is 0.
+⁴ The byte only carries a meaningful current while the compressor runs. When it is stopped (unit OFF or FAN ONLY) the byte sits at a per-unit floor (3 on the 115V MRCOOL, 0 on the 220V Cooper & Hunter) that the formula would misread as ~1 A, so `current_draw` reports the ~0.2 A standby baseline measured with a clamp meter whenever `compressor_frequency_actual_int` (response 2, byte 3) is 0.
+
+⁵ Compressor frequency is reported by several controllers: the indoor unit requests a target (`compressor_frequency_indoor_target`, 0x04[8]) and the outdoor board resolves that into its own target (`…_outdoor_target`, 0x02[2]) and control (`…_outdoor_control`, 0x04[7]) values, while the actual running frequency is available both as a whole number (`…_actual_int`, 0x02[3]) and — pairing that with the sub-Hz fraction in 0x05[2] — to two decimals (`…_actual_float`). The `…_float` reading needs both response 0x02 and 0x05 fresh. Still tentative: not yet cross-checked across OEMs.
 
 `operating_mode` is a raw integer code:
 
@@ -149,8 +154,8 @@ sensor:
   - platform: midea_telemetry
     outdoor_coil_temperature:
       name: Outdoor coil temperature
-    compressor_frequency_actual:
-      name: Compressor frequency (actual)
+    compressor_frequency_actual_int:
+      name: Compressor frequency (actual, int)
     # ... every field from the Fields table below is available
 ```
 

--- a/README.md
+++ b/README.md
@@ -19,11 +19,11 @@ The following sensors are currently supported:
 | `discharge_temperature` | °C | 0x00[6] | Steinhart–Hart ² |
 | `ipm_temperature` | °C | 0x01[4] | NTC β-model ¹ |
 | `operating_mode` | raw | 0x02[8] | `b` |
-| `compressor_frequency_indoor_target` | Hz | 0x04[8] | `b` ⁵ |
+| `compressor_frequency_indoor_target` | Hz | 0x04[8] | `b` |
 | `compressor_frequency_outdoor_target` | Hz | 0x02[2] | `b` |
 | `compressor_frequency_actual_int` | Hz | 0x02[3] | `b` |
-| `compressor_frequency_actual_float` | Hz | 0x02[3] + 0x05[2] | `b₀₂₋₃ + b₀₅₋₂ / 100` ⁵ |
-| `compressor_frequency_outdoor_control` | Hz | 0x04[7] | `b` ⁵ |
+| `compressor_frequency_actual_float` | Hz | 0x02[3] + 0x05[2] | `b₀₂₋₃ + b₀₅₋₂ / 100` |
+| `compressor_frequency_outdoor_control` | Hz | 0x04[7] | `b` |
 | `outdoor_fan_speed` | raw | 0x00[7+8] | `b₇ \| b₈ << 8` (uint16 LE) |
 | `eev_steps` | raw | 0x01[5+6] | `b₅ \| b₆ << 8` (uint16 LE) |
 | `indoor_setpoint` | °C | 0x01[7] | `b < 50 ? b : (b − 50) / 2` ³ |
@@ -47,8 +47,6 @@ T = 1 / (2.873×10⁻³ + 2.491×10⁻⁴ · L + 9.74×10⁻⁷ · L³) − 273.
 ³ Two OEM encodings, told apart by range (a real set-point is ~16–32 °C): whole-degree (16–32) or half-degree +50 (82–114).
 
 ⁴ The byte only carries a meaningful current while the compressor runs. When it is stopped (unit OFF or FAN ONLY) the byte sits at a per-unit floor (3 on the 115V MRCOOL, 0 on the 220V Cooper & Hunter) that the formula would misread as ~1 A, so `current_draw` reports the ~0.2 A standby baseline measured with a clamp meter whenever `compressor_frequency_actual_int` (response 2, byte 3) is 0.
-
-⁵ Compressor frequency is reported by several controllers: the indoor unit requests a target (`compressor_frequency_indoor_target`, 0x04[8]) and the outdoor board resolves that into its own target (`…_outdoor_target`, 0x02[2]) and control (`…_outdoor_control`, 0x04[7]) values, while the actual running frequency is available both as a whole number (`…_actual_int`, 0x02[3]) and — pairing that with the sub-Hz fraction in 0x05[2] — to two decimals (`…_actual_float`). The `…_float` reading needs both response 0x02 and 0x05 fresh. Still tentative: not yet cross-checked across OEMs.
 
 `operating_mode` is a raw integer code:
 

--- a/UART-comparison.md
+++ b/UART-comparison.md
@@ -13,8 +13,8 @@ The UART port is more easily accessible than the diagnostic port on the ODU, whi
 | `discharge_temperature`       | ✅ | ❌ | |
 | `ipm_temperature`             | ❌ | ❌ | |
 | `operating_mode`              | ✅ | ✅ | |
-| `compressor_frequency_target` | ✅ | ❌ | |
-| `compressor_frequency_actual` | ✅ | ✅ | |
+| `compressor_frequency_outdoor_target`     | ✅ | ❌ | |
+| `compressor_frequency_actual_int` | ✅ | ✅ | |
 | `outdoor_fan_speed`           | ✅ | ❌ | |
 | `eev_steps`                   | ✅ | ❌ | |
 | `indoor_setpoint`             | ✅ | ✅ | |

--- a/components/midea_telemetry/midea_telemetry.cpp
+++ b/components/midea_telemetry/midea_telemetry.cpp
@@ -97,38 +97,60 @@ static std::string frame_hex(const uint8_t *frame) {
 #endif
 
 // ── mapped parameters ─────────────────────────────────────────────────────────
-// Every decoded parameter - its response type, byte offset(s) and conversion -
-// is described exactly once here, so update() (which publishes to sensors) and
-// the /json endpoint (which serves every parameter, whether or not a sensor is
-// configured for it) can never drift apart.
+// Every decoded parameter - the frame(s) and byte offset(s) it derives from and
+// its conversion - is described exactly once here, so update() (which publishes
+// to sensors) and the /json endpoint (which serves every parameter, whether or
+// not a sensor is configured for it) can never drift apart.
+
+// A single raw byte a value derives from: which response frame it lives in, and
+// its offset within that frame. Keeping the frame per byte (rather than one
+// shared response type) lets a value combine bytes from several frames - e.g.
+// compressor_frequency_actual_float pairs 0x02[3] with 0x05[2].
+struct ByteRef {
+  uint8_t frame;
+  uint8_t byte;
+};
+
 struct MappedParam {
   const char *name;
-  uint8_t type;      // response type read (also the freshness source)
-  uint8_t bytes[2];  // byte offset(s) within that response the value derives from
-  uint8_t num_bytes;
+  ByteRef sources[2];   // raw byte(s) the value derives from, across any frame(s)
+  uint8_t num_sources;
   float (*decode)(const uint8_t frames[NUM_RESPONSE_TYPES][FRAME_SIZE]);
 };
 
 // clang-format off
 static const MappedParam MAPPED_PARAMS[] = {
-    {"indoor_ambient_temperature",   0x00, {2},    1, [](const uint8_t f[][FRAME_SIZE]) { return ntc_temp(f[0x00][2]); }},
-    {"indoor_coil_temperature",      0x00, {3},    1, [](const uint8_t f[][FRAME_SIZE]) { return ntc_temp(f[0x00][3]); }},
-    {"outdoor_ambient_temperature",  0x00, {5},    1, [](const uint8_t f[][FRAME_SIZE]) { return ntc_temp(f[0x00][5]); }},
-    {"outdoor_coil_temperature",     0x00, {4},    1, [](const uint8_t f[][FRAME_SIZE]) { return ntc_temp(f[0x00][4]); }},
-    {"discharge_temperature",        0x00, {6},    1, [](const uint8_t f[][FRAME_SIZE]) { return discharge_temp(f[0x00][6]); }},
-    {"ipm_temperature",              0x01, {4},    1, [](const uint8_t f[][FRAME_SIZE]) { return ntc_temp(f[0x01][4]); }},
-    {"operating_mode",               0x02, {8},    1, [](const uint8_t f[][FRAME_SIZE]) { return (float) f[0x02][8]; }},
-    {"compressor_frequency_target",  0x02, {2},    1, [](const uint8_t f[][FRAME_SIZE]) { return (float) f[0x02][2]; }},
-    {"compressor_frequency_actual",  0x02, {3},    1, [](const uint8_t f[][FRAME_SIZE]) { return (float) f[0x02][3]; }},
-    {"outdoor_fan_speed",            0x00, {7, 8}, 2, [](const uint8_t f[][FRAME_SIZE]) { return uint16(f[0x00][7], f[0x00][8]); }},
-    {"eev_steps",                    0x01, {5, 6}, 2, [](const uint8_t f[][FRAME_SIZE]) { return uint16(f[0x01][5], f[0x01][6]); }},
-    {"indoor_setpoint",              0x01, {7},    1, [](const uint8_t f[][FRAME_SIZE]) { return indoor_setpoint(f[0x01][7]); }},
-    {"input_voltage",                0x01, {3},    1, [](const uint8_t f[][FRAME_SIZE]) { return ac_voltage(f[0x01][3]); }},
-    {"current_draw",                 0x01, {2},    1, [](const uint8_t f[][FRAME_SIZE]) { return current_draw(f[0x01][2], f[0x02][3]); }},
-    {"dc_bus_voltage",               0x03, {6},    1, [](const uint8_t f[][FRAME_SIZE]) { return dc_bus_voltage(f[0x03][6]); }},
+    {"indoor_ambient_temperature",                {{0x00, 2}},            1, [](const uint8_t f[][FRAME_SIZE]) { return ntc_temp(f[0x00][2]); }},
+    {"indoor_coil_temperature",                   {{0x00, 3}},            1, [](const uint8_t f[][FRAME_SIZE]) { return ntc_temp(f[0x00][3]); }},
+    {"outdoor_ambient_temperature",               {{0x00, 5}},            1, [](const uint8_t f[][FRAME_SIZE]) { return ntc_temp(f[0x00][5]); }},
+    {"outdoor_coil_temperature",                  {{0x00, 4}},            1, [](const uint8_t f[][FRAME_SIZE]) { return ntc_temp(f[0x00][4]); }},
+    {"discharge_temperature",                     {{0x00, 6}},            1, [](const uint8_t f[][FRAME_SIZE]) { return discharge_temp(f[0x00][6]); }},
+    {"ipm_temperature",                           {{0x01, 4}},            1, [](const uint8_t f[][FRAME_SIZE]) { return ntc_temp(f[0x01][4]); }},
+    {"operating_mode",                            {{0x02, 8}},            1, [](const uint8_t f[][FRAME_SIZE]) { return (float) f[0x02][8]; }},
+    {"compressor_frequency_indoor_target",        {{0x04, 8}},            1, [](const uint8_t f[][FRAME_SIZE]) { return (float) f[0x04][8]; }},
+    {"compressor_frequency_outdoor_target",       {{0x02, 2}},            1, [](const uint8_t f[][FRAME_SIZE]) { return (float) f[0x02][2]; }},
+    {"compressor_frequency_actual_int",           {{0x02, 3}},            1, [](const uint8_t f[][FRAME_SIZE]) { return (float) f[0x02][3]; }},
+    {"compressor_frequency_actual_float",         {{0x02, 3}, {0x05, 2}}, 2, [](const uint8_t f[][FRAME_SIZE]) { return f[0x02][3] + f[0x05][2] / 100.0f; }},
+    {"compressor_frequency_outdoor_control",      {{0x04, 7}},            1, [](const uint8_t f[][FRAME_SIZE]) { return (float) f[0x04][7]; }},
+    {"outdoor_fan_speed",                         {{0x00, 7}, {0x00, 8}}, 2, [](const uint8_t f[][FRAME_SIZE]) { return uint16(f[0x00][7], f[0x00][8]); }},
+    {"eev_steps",                                 {{0x01, 5}, {0x01, 6}}, 2, [](const uint8_t f[][FRAME_SIZE]) { return uint16(f[0x01][5], f[0x01][6]); }},
+    {"indoor_setpoint",                           {{0x01, 7}},            1, [](const uint8_t f[][FRAME_SIZE]) { return indoor_setpoint(f[0x01][7]); }},
+    {"input_voltage",                             {{0x01, 3}},            1, [](const uint8_t f[][FRAME_SIZE]) { return ac_voltage(f[0x01][3]); }},
+    {"current_draw",                              {{0x01, 2}, {0x02, 3}}, 2, [](const uint8_t f[][FRAME_SIZE]) { return current_draw(f[0x01][2], f[0x02][3]); }},
+    {"dc_bus_voltage",                            {{0x03, 6}},            1, [](const uint8_t f[][FRAME_SIZE]) { return dc_bus_voltage(f[0x03][6]); }},
 };
 // clang-format on
 static const size_t NUM_MAPPED_PARAMS = sizeof(MAPPED_PARAMS) / sizeof(MAPPED_PARAMS[0]);
+
+// A parameter is fresh only when every frame it derives from is fresh - a value
+// combining two frames (compressor_frequency_actual_float) needs both.
+static bool param_fresh(const MappedParam &p, const bool fresh[NUM_RESPONSE_TYPES]) {
+  for (uint8_t i = 0; i < p.num_sources; i++) {
+    if (!fresh[p.sources[i].frame])
+      return false;
+  }
+  return true;
+}
 
 // ── bus primitives (mirroring inverter-tester-emulator.ino) ───────────────────
 
@@ -298,19 +320,29 @@ void MideaTelemetry::update() {
 
   // Same order as MAPPED_PARAMS; the static_assert guards the pairing.
   sensor::Sensor *const sensors[] = {
-      this->indoor_ambient_temperature_sensor_,   this->indoor_coil_temperature_sensor_,
-      this->outdoor_ambient_temperature_sensor_,  this->outdoor_coil_temperature_sensor_,
-      this->discharge_temperature_sensor_,        this->ipm_temperature_sensor_,
-      this->operating_mode_sensor_,               this->compressor_frequency_target_sensor_,
-      this->compressor_frequency_actual_sensor_,  this->outdoor_fan_speed_sensor_,
-      this->eev_steps_sensor_,                    this->indoor_setpoint_sensor_,
-      this->input_voltage_sensor_,                this->current_draw_sensor_,
+      this->indoor_ambient_temperature_sensor_,
+      this->indoor_coil_temperature_sensor_,
+      this->outdoor_ambient_temperature_sensor_,
+      this->outdoor_coil_temperature_sensor_,
+      this->discharge_temperature_sensor_,
+      this->ipm_temperature_sensor_,
+      this->operating_mode_sensor_,
+      this->compressor_frequency_indoor_target_sensor_,
+      this->compressor_frequency_outdoor_target_sensor_,
+      this->compressor_frequency_actual_int_sensor_,
+      this->compressor_frequency_actual_float_sensor_,
+      this->compressor_frequency_outdoor_control_sensor_,
+      this->outdoor_fan_speed_sensor_,
+      this->eev_steps_sensor_,
+      this->indoor_setpoint_sensor_,
+      this->input_voltage_sensor_,
+      this->current_draw_sensor_,
       this->dc_bus_voltage_sensor_,
   };
   static_assert(sizeof(sensors) / sizeof(sensors[0]) == NUM_MAPPED_PARAMS,
                 "sensors[] must line up 1:1 with MAPPED_PARAMS");
   for (size_t i = 0; i < NUM_MAPPED_PARAMS; i++)
-    publish(sensors[i], fresh[MAPPED_PARAMS[i].type], MAPPED_PARAMS[i].decode(frames));
+    publish(sensors[i], param_fresh(MAPPED_PARAMS[i], fresh), MAPPED_PARAMS[i].decode(frames));
 }
 
 void MideaTelemetry::dump_config() {
@@ -325,8 +357,11 @@ void MideaTelemetry::dump_config() {
   LOG_SENSOR("  ", "Compressor discharge temperature", this->discharge_temperature_sensor_);
   LOG_SENSOR("  ", "IPM temperature", this->ipm_temperature_sensor_);
   LOG_SENSOR("  ", "Operating mode", this->operating_mode_sensor_);
-  LOG_SENSOR("  ", "Compressor frequency (target)", this->compressor_frequency_target_sensor_);
-  LOG_SENSOR("  ", "Compressor frequency (actual)", this->compressor_frequency_actual_sensor_);
+  LOG_SENSOR("  ", "Compressor frequency (indoor target)", this->compressor_frequency_indoor_target_sensor_);
+  LOG_SENSOR("  ", "Compressor frequency (outdoor target)", this->compressor_frequency_outdoor_target_sensor_);
+  LOG_SENSOR("  ", "Compressor frequency (actual, int)", this->compressor_frequency_actual_int_sensor_);
+  LOG_SENSOR("  ", "Compressor frequency (actual, float)", this->compressor_frequency_actual_float_sensor_);
+  LOG_SENSOR("  ", "Compressor frequency (outdoor control)", this->compressor_frequency_outdoor_control_sensor_);
   LOG_SENSOR("  ", "Outdoor fan speed", this->outdoor_fan_speed_sensor_);
   LOG_SENSOR("  ", "EEV opening steps", this->eev_steps_sensor_);
   LOG_SENSOR("  ", "Indoor set-point", this->indoor_setpoint_sensor_);
@@ -373,7 +408,7 @@ void MideaTelemetry::handleRequest(AsyncWebServerRequest *request) {
     body += p.name;
     body += "\":";
     const float value = p.decode(frames);
-    if (fresh[p.type] && !std::isnan(value)) {
+    if (param_fresh(p, fresh) && !std::isnan(value)) {
       snprintf(buf, sizeof(buf), "%g", value);
       body += buf;
     } else {
@@ -392,11 +427,12 @@ void MideaTelemetry::handleRequest(AsyncWebServerRequest *request) {
     body += '"';
     body += p.name;
     body += "\":{";
-    for (uint8_t j = 0; j < p.num_bytes; j++) {
-      snprintf(buf, sizeof(buf), "%s\"0x%02X[%u]\":", j == 0 ? "" : ",", (unsigned) p.type, (unsigned) p.bytes[j]);
+    for (uint8_t j = 0; j < p.num_sources; j++) {
+      const ByteRef &s = p.sources[j];
+      snprintf(buf, sizeof(buf), "%s\"0x%02X[%u]\":", j == 0 ? "" : ",", (unsigned) s.frame, (unsigned) s.byte);
       body += buf;
-      if (valid[p.type]) {
-        snprintf(buf, sizeof(buf), "%u", (unsigned) frames[p.type][p.bytes[j]]);
+      if (valid[s.frame]) {
+        snprintf(buf, sizeof(buf), "%u", (unsigned) frames[s.frame][s.byte]);
         body += buf;
       } else {
         body += "null";

--- a/components/midea_telemetry/midea_telemetry.h
+++ b/components/midea_telemetry/midea_telemetry.h
@@ -48,8 +48,11 @@ class MideaTelemetry : public PollingComponent
   void set_discharge_temperature_sensor(sensor::Sensor *s) { this->discharge_temperature_sensor_ = s; }
   void set_ipm_temperature_sensor(sensor::Sensor *s) { this->ipm_temperature_sensor_ = s; }
   void set_operating_mode_sensor(sensor::Sensor *s) { this->operating_mode_sensor_ = s; }
-  void set_compressor_frequency_target_sensor(sensor::Sensor *s) { this->compressor_frequency_target_sensor_ = s; }
-  void set_compressor_frequency_actual_sensor(sensor::Sensor *s) { this->compressor_frequency_actual_sensor_ = s; }
+  void set_compressor_frequency_indoor_target_sensor(sensor::Sensor *s) { this->compressor_frequency_indoor_target_sensor_ = s; }
+  void set_compressor_frequency_outdoor_target_sensor(sensor::Sensor *s) { this->compressor_frequency_outdoor_target_sensor_ = s; }
+  void set_compressor_frequency_actual_int_sensor(sensor::Sensor *s) { this->compressor_frequency_actual_int_sensor_ = s; }
+  void set_compressor_frequency_actual_float_sensor(sensor::Sensor *s) { this->compressor_frequency_actual_float_sensor_ = s; }
+  void set_compressor_frequency_outdoor_control_sensor(sensor::Sensor *s) { this->compressor_frequency_outdoor_control_sensor_ = s; }
   void set_outdoor_fan_speed_sensor(sensor::Sensor *s) { this->outdoor_fan_speed_sensor_ = s; }
   void set_eev_steps_sensor(sensor::Sensor *s) { this->eev_steps_sensor_ = s; }
   void set_indoor_setpoint_sensor(sensor::Sensor *s) { this->indoor_setpoint_sensor_ = s; }
@@ -84,8 +87,11 @@ class MideaTelemetry : public PollingComponent
   sensor::Sensor *discharge_temperature_sensor_{nullptr};
   sensor::Sensor *ipm_temperature_sensor_{nullptr};
   sensor::Sensor *operating_mode_sensor_{nullptr};
-  sensor::Sensor *compressor_frequency_target_sensor_{nullptr};
-  sensor::Sensor *compressor_frequency_actual_sensor_{nullptr};
+  sensor::Sensor *compressor_frequency_indoor_target_sensor_{nullptr};
+  sensor::Sensor *compressor_frequency_outdoor_target_sensor_{nullptr};
+  sensor::Sensor *compressor_frequency_actual_int_sensor_{nullptr};
+  sensor::Sensor *compressor_frequency_actual_float_sensor_{nullptr};
+  sensor::Sensor *compressor_frequency_outdoor_control_sensor_{nullptr};
   sensor::Sensor *outdoor_fan_speed_sensor_{nullptr};
   sensor::Sensor *eev_steps_sensor_{nullptr};
   sensor::Sensor *indoor_setpoint_sensor_{nullptr};

--- a/components/midea_telemetry/sensor.py
+++ b/components/midea_telemetry/sensor.py
@@ -41,13 +41,31 @@ SENSORS = {
         state_class=STATE_CLASS_MEASUREMENT,
         accuracy_decimals=0,
     ),
-    "compressor_frequency_target": sensor.sensor_schema(
+    "compressor_frequency_indoor_target": sensor.sensor_schema(
         unit_of_measurement=UNIT_HERTZ,
         device_class=DEVICE_CLASS_FREQUENCY,
         state_class=STATE_CLASS_MEASUREMENT,
         accuracy_decimals=0,
     ),
-    "compressor_frequency_actual": sensor.sensor_schema(
+    "compressor_frequency_outdoor_target": sensor.sensor_schema(
+        unit_of_measurement=UNIT_HERTZ,
+        device_class=DEVICE_CLASS_FREQUENCY,
+        state_class=STATE_CLASS_MEASUREMENT,
+        accuracy_decimals=0,
+    ),
+    "compressor_frequency_actual_int": sensor.sensor_schema(
+        unit_of_measurement=UNIT_HERTZ,
+        device_class=DEVICE_CLASS_FREQUENCY,
+        state_class=STATE_CLASS_MEASUREMENT,
+        accuracy_decimals=0,
+    ),
+    "compressor_frequency_actual_float": sensor.sensor_schema(
+        unit_of_measurement=UNIT_HERTZ,
+        device_class=DEVICE_CLASS_FREQUENCY,
+        state_class=STATE_CLASS_MEASUREMENT,
+        accuracy_decimals=2,
+    ),
+    "compressor_frequency_outdoor_control": sensor.sensor_schema(
         unit_of_measurement=UNIT_HERTZ,
         device_class=DEVICE_CLASS_FREQUENCY,
         state_class=STATE_CLASS_MEASUREMENT,

--- a/example_midea_telemetry.yaml
+++ b/example_midea_telemetry.yaml
@@ -53,10 +53,16 @@ sensor:
       name: IPM temperature
     operating_mode:
       name: Operating mode
-    compressor_frequency_target:
-      name: Compressor frequency (target)
-    compressor_frequency_actual:
-      name: Compressor frequency (actual)
+    compressor_frequency_indoor_target:
+      name: Compressor frequency (indoor target)
+    compressor_frequency_outdoor_target:
+      name: Compressor frequency (outdoor target)
+    compressor_frequency_actual_int:
+      name: Compressor frequency (actual, int)
+    compressor_frequency_actual_float:
+      name: Compressor frequency (actual, float)
+    compressor_frequency_outdoor_control:
+      name: Compressor frequency (outdoor control)
     outdoor_fan_speed:
       name: Outdoor fan speed
     eev_steps:

--- a/influxdb-grafana/README.md
+++ b/influxdb-grafana/README.md
@@ -55,9 +55,11 @@ and Grafana renders a provisioned dashboard on top — no Home Assistant require
 | Dashboard | `grafana/dashboards/midea-telemetry.json` |
 
 The dashboard groups every field from the [Fields table](../README.md#fields):
-coil/ambient temps, discharge & IPM temps, compressor frequency (target vs
-actual), outdoor fan speed & EEV steps, input/DC-bus voltage, current draw, and
-set-point/operating mode — filtered by the selected device(s).
+coil/ambient temps, discharge & IPM temps, the compressor-frequency family
+(indoor/outdoor target, actual as int and float, and outdoor control —
+under the "Compressor Frequency (extended)" row at the bottom), outdoor fan
+speed & EEV steps, input/DC-bus voltage, current draw, and set-point/operating
+mode — filtered by the selected device(s).
 
 ## Verify data is flowing
 

--- a/influxdb-grafana/grafana/dashboards/midea-telemetry.json
+++ b/influxdb-grafana/grafana/dashboards/midea-telemetry.json
@@ -472,7 +472,7 @@
       "type": "timeseries",
       "title": "Compressor Frequency (actual, int)",
       "datasource": { "type": "influxdb", "uid": "midea-influxdb" },
-      "gridPos": { "h": 8, "w": 6, "x": 12, "y": 31 },
+      "gridPos": { "h": 8, "w": 6, "x": 0, "y": 31 },
       "fieldConfig": {
         "defaults": {
           "unit": "suffix:Hz",
@@ -645,7 +645,7 @@
       "type": "timeseries",
       "title": "Compressor Frequency (outdoor target)",
       "datasource": { "type": "influxdb", "uid": "midea-influxdb" },
-      "gridPos": { "h": 8, "w": 6, "x": 6, "y": 31 },
+      "gridPos": { "h": 8, "w": 6, "x": 12, "y": 31 },
       "fieldConfig": {
         "defaults": {
           "unit": "suffix:Hz",
@@ -923,7 +923,7 @@
       "gridPos": {
         "h": 8,
         "w": 6,
-        "x": 0,
+        "x": 6,
         "y": 31
       },
       "fieldConfig": {

--- a/influxdb-grafana/grafana/dashboards/midea-telemetry.json
+++ b/influxdb-grafana/grafana/dashboards/midea-telemetry.json
@@ -472,7 +472,7 @@
       "type": "timeseries",
       "title": "Compressor Frequency (actual, int)",
       "datasource": { "type": "influxdb", "uid": "midea-influxdb" },
-      "gridPos": { "h": 8, "w": 6, "x": 12, "y": 6 },
+      "gridPos": { "h": 8, "w": 6, "x": 12, "y": 31 },
       "fieldConfig": {
         "defaults": {
           "unit": "suffix:Hz",
@@ -645,7 +645,7 @@
       "type": "timeseries",
       "title": "Compressor Frequency (outdoor target)",
       "datasource": { "type": "influxdb", "uid": "midea-influxdb" },
-      "gridPos": { "h": 8, "w": 6, "x": 12, "y": 14 },
+      "gridPos": { "h": 8, "w": 6, "x": 6, "y": 31 },
       "fieldConfig": {
         "defaults": {
           "unit": "suffix:Hz",
@@ -732,7 +732,7 @@
       "type": "timeseries",
       "title": "AC Voltage",
       "datasource": { "type": "influxdb", "uid": "midea-influxdb" },
-      "gridPos": { "h": 8, "w": 6, "x": 18, "y": 14 },
+      "gridPos": { "h": 8, "w": 6, "x": 12, "y": 14 },
       "fieldConfig": {
         "defaults": {
           "unit": "volt",
@@ -861,7 +861,7 @@
       "type": "timeseries",
       "title": "DC Bus Voltage",
       "datasource": { "type": "influxdb", "uid": "midea-influxdb" },
-      "gridPos": { "h": 8, "w": 6, "x": 18, "y": 22 },
+      "gridPos": { "h": 8, "w": 6, "x": 18, "y": 14 },
       "fieldConfig": {
         "defaults": {
           "unit": "volt",
@@ -902,7 +902,7 @@
     {
       "id": 20,
       "type": "row",
-      "title": "Compressor Frequency (extended — issue #34)",
+      "title": "Compressor Frequency (extended)",
       "collapsed": false,
       "gridPos": {
         "h": 1,
@@ -1027,8 +1027,8 @@
       "gridPos": {
         "h": 8,
         "w": 6,
-        "x": 6,
-        "y": 31
+        "x": 12,
+        "y": 6
       },
       "fieldConfig": {
         "defaults": {
@@ -1131,7 +1131,7 @@
       "gridPos": {
         "h": 8,
         "w": 6,
-        "x": 12,
+        "x": 18,
         "y": 31
       },
       "fieldConfig": {

--- a/influxdb-grafana/grafana/dashboards/midea-telemetry.json
+++ b/influxdb-grafana/grafana/dashboards/midea-telemetry.json
@@ -64,7 +64,7 @@
   "timezone": "browser",
   "title": "Midea Telemetry",
   "uid": "midea-telemetry",
-  "version": 5,
+  "version": 6,
   "weekStart": "",
   "panels": [
     {
@@ -225,12 +225,12 @@
         {
           "datasource": { "type": "influxdb", "uid": "midea-influxdb" },
           "refId": "A",
-          "query": "from(bucket: \"${bucket}\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"midea\")\n  |> filter(fn: (r) => r._field == \"compressor_frequency_actual\")\n  |> filter(fn: (r) => r.device == \"${device}\")\n  |> last()"
+          "query": "from(bucket: \"${bucket}\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"midea\")\n  |> filter(fn: (r) => r._field == \"compressor_frequency_actual_int\")\n  |> filter(fn: (r) => r.device == \"${device}\")\n  |> last()"
         },
         {
           "datasource": { "type": "influxdb", "uid": "midea-influxdb" },
           "refId": "B",
-          "query": "from(bucket: \"${bucket}\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"midea\")\n  |> filter(fn: (r) => r._field == \"compressor_frequency_target\")\n  |> filter(fn: (r) => r.device == \"${device}\")\n  |> last()"
+          "query": "from(bucket: \"${bucket}\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"midea\")\n  |> filter(fn: (r) => r._field == \"compressor_frequency_outdoor_target\")\n  |> filter(fn: (r) => r.device == \"${device}\")\n  |> last()"
         }
       ]
     },
@@ -470,7 +470,7 @@
     {
       "id": 8,
       "type": "timeseries",
-      "title": "Compressor Frequency (actual)",
+      "title": "Compressor Frequency (actual, int)",
       "datasource": { "type": "influxdb", "uid": "midea-influxdb" },
       "gridPos": { "h": 8, "w": 6, "x": 12, "y": 6 },
       "fieldConfig": {
@@ -501,7 +501,7 @@
         {
           "datasource": { "type": "influxdb", "uid": "midea-influxdb" },
           "refId": "A",
-          "query": "from(bucket: \"${bucket}\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"midea\")\n  |> filter(fn: (r) => r._field == \"compressor_frequency_actual\")\n  |> filter(fn: (r) => r.device == \"${device}\")\n  |> drop(columns: [\"url\", \"device\"])\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)"
+          "query": "from(bucket: \"${bucket}\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"midea\")\n  |> filter(fn: (r) => r._field == \"compressor_frequency_actual_int\")\n  |> filter(fn: (r) => r.device == \"${device}\")\n  |> drop(columns: [\"url\", \"device\"])\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)"
         },
         {
           "datasource": { "type": "influxdb", "uid": "midea-influxdb" },
@@ -643,7 +643,7 @@
     {
       "id": 7,
       "type": "timeseries",
-      "title": "Compressor Frequency (target)",
+      "title": "Compressor Frequency (outdoor target)",
       "datasource": { "type": "influxdb", "uid": "midea-influxdb" },
       "gridPos": { "h": 8, "w": 6, "x": 12, "y": 14 },
       "fieldConfig": {
@@ -674,7 +674,7 @@
         {
           "datasource": { "type": "influxdb", "uid": "midea-influxdb" },
           "refId": "A",
-          "query": "from(bucket: \"${bucket}\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"midea\")\n  |> filter(fn: (r) => r._field == \"compressor_frequency_target\")\n  |> filter(fn: (r) => r.device == \"${device}\")\n  |> drop(columns: [\"url\", \"device\"])\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)"
+          "query": "from(bucket: \"${bucket}\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"midea\")\n  |> filter(fn: (r) => r._field == \"compressor_frequency_outdoor_target\")\n  |> filter(fn: (r) => r.device == \"${device}\")\n  |> drop(columns: [\"url\", \"device\"])\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)"
         },
         {
           "datasource": { "type": "influxdb", "uid": "midea-influxdb" },
@@ -894,6 +894,331 @@
         },
         {
           "datasource": { "type": "influxdb", "uid": "midea-influxdb" },
+          "refId": "Z",
+          "query": "import \"array\"\narray.from(rows: [{_time: v.timeRangeStart, _value: 0.0}, {_time: v.timeRangeStop, _value: 0.0}])\n  |> filter(fn: (r) => \"${ymin}\" == \"0\")"
+        }
+      ]
+    },
+    {
+      "id": 20,
+      "type": "row",
+      "title": "Compressor Frequency (extended — issue #34)",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 30
+      },
+      "panels": []
+    },
+    {
+      "id": 21,
+      "type": "timeseries",
+      "title": "Compressor Frequency (indoor target)",
+      "datasource": {
+        "type": "influxdb",
+        "uid": "midea-influxdb"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 0,
+        "y": 31
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "suffix:Hz",
+          "decimals": 0,
+          "color": {
+            "mode": "fixed",
+            "fixedColor": "light-blue"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "stepAfter",
+            "lineWidth": 1,
+            "fillOpacity": 15,
+            "gradientMode": "opacity",
+            "showPoints": "never",
+            "spanNulls": true
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byFrameRefID",
+              "options": "Z"
+            },
+            "properties": [
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "legend": true,
+                  "tooltip": true,
+                  "viz": false
+                }
+              },
+              {
+                "id": "custom.lineWidth",
+                "value": 0
+              },
+              {
+                "id": "custom.fillOpacity",
+                "value": 0
+              },
+              {
+                "id": "custom.showPoints",
+                "value": "never"
+              },
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "rgba(0,0,0,0)"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "min",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "midea-influxdb"
+          },
+          "refId": "A",
+          "query": "from(bucket: \"${bucket}\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"midea\")\n  |> filter(fn: (r) => r._field == \"compressor_frequency_indoor_target\")\n  |> filter(fn: (r) => r.device == \"${device}\")\n  |> drop(columns: [\"url\", \"device\"])\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)"
+        },
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "midea-influxdb"
+          },
+          "refId": "Z",
+          "query": "import \"array\"\narray.from(rows: [{_time: v.timeRangeStart, _value: 0.0}, {_time: v.timeRangeStop, _value: 0.0}])\n  |> filter(fn: (r) => \"${ymin}\" == \"0\")"
+        }
+      ]
+    },
+    {
+      "id": 22,
+      "type": "timeseries",
+      "title": "Compressor Frequency (actual, float)",
+      "datasource": {
+        "type": "influxdb",
+        "uid": "midea-influxdb"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 6,
+        "y": 31
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "suffix:Hz",
+          "decimals": 2,
+          "color": {
+            "mode": "fixed",
+            "fixedColor": "yellow"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "stepAfter",
+            "lineWidth": 1,
+            "fillOpacity": 15,
+            "gradientMode": "opacity",
+            "showPoints": "never",
+            "spanNulls": true
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byFrameRefID",
+              "options": "Z"
+            },
+            "properties": [
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "legend": true,
+                  "tooltip": true,
+                  "viz": false
+                }
+              },
+              {
+                "id": "custom.lineWidth",
+                "value": 0
+              },
+              {
+                "id": "custom.fillOpacity",
+                "value": 0
+              },
+              {
+                "id": "custom.showPoints",
+                "value": "never"
+              },
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "rgba(0,0,0,0)"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "min",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "midea-influxdb"
+          },
+          "refId": "A",
+          "query": "from(bucket: \"${bucket}\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"midea\")\n  |> filter(fn: (r) => r._field == \"compressor_frequency_actual_float\")\n  |> filter(fn: (r) => r.device == \"${device}\")\n  |> drop(columns: [\"url\", \"device\"])\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)"
+        },
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "midea-influxdb"
+          },
+          "refId": "Z",
+          "query": "import \"array\"\narray.from(rows: [{_time: v.timeRangeStart, _value: 0.0}, {_time: v.timeRangeStop, _value: 0.0}])\n  |> filter(fn: (r) => \"${ymin}\" == \"0\")"
+        }
+      ]
+    },
+    {
+      "id": 23,
+      "type": "timeseries",
+      "title": "Compressor Frequency (outdoor control)",
+      "datasource": {
+        "type": "influxdb",
+        "uid": "midea-influxdb"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 12,
+        "y": 31
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "suffix:Hz",
+          "decimals": 0,
+          "color": {
+            "mode": "fixed",
+            "fixedColor": "orange"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "stepAfter",
+            "lineWidth": 1,
+            "fillOpacity": 15,
+            "gradientMode": "opacity",
+            "showPoints": "never",
+            "spanNulls": true
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byFrameRefID",
+              "options": "Z"
+            },
+            "properties": [
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "legend": true,
+                  "tooltip": true,
+                  "viz": false
+                }
+              },
+              {
+                "id": "custom.lineWidth",
+                "value": 0
+              },
+              {
+                "id": "custom.fillOpacity",
+                "value": 0
+              },
+              {
+                "id": "custom.showPoints",
+                "value": "never"
+              },
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "rgba(0,0,0,0)"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "min",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "midea-influxdb"
+          },
+          "refId": "A",
+          "query": "from(bucket: \"${bucket}\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"midea\")\n  |> filter(fn: (r) => r._field == \"compressor_frequency_outdoor_control\")\n  |> filter(fn: (r) => r.device == \"${device}\")\n  |> drop(columns: [\"url\", \"device\"])\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)"
+        },
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "midea-influxdb"
+          },
           "refId": "Z",
           "query": "import \"array\"\narray.from(rows: [{_time: v.timeRangeStart, _value: 0.0}, {_time: v.timeRangeStop, _value: 0.0}])\n  |> filter(fn: (r) => \"${ymin}\" == \"0\")"
         }


### PR DESCRIPTION
Implements #34.

## Summary
Splits the single compressor-frequency reading into the five controller-specific values requested in the issue, and adds the plumbing that makes the cross-frame one possible.

## `MappedParam`: multi-frame byte sources
Replaces the old `uint8_t type` + `bytes[]` (a single shared response frame) with a `ByteRef{frame, byte}` array, so a decoded value can combine bytes from several frames. A new `param_fresh()` gates each value on **all** its source frames being fresh, and the `/json` `source_bytes` section now reports the true per-byte frame — fixing the previously incomplete disclosure for cross-frame values (`current_draw` now lists both `0x01[2]` and `0x02[3]`).

## Compressor-frequency sensors
Replaces `compressor_frequency_target` / `compressor_frequency_actual` with:

| Sensor | Bytes |
|---|---|
| `compressor_frequency_indoor_target` | 0x04[8] |
| `compressor_frequency_outdoor_target` | 0x02[2] |
| `compressor_frequency_actual_int` | 0x02[3] |
| `compressor_frequency_actual_float` | 0x02[3] + 0x05[2] / 100 |
| `compressor_frequency_outdoor_control` | 0x04[7] |

Wired through `sensor.py`, the header, `MAPPED_PARAMS` / `sensors[]` / `dump_config` (kept 1:1), the example YAML, the README table, and `UART-comparison.md`.

## Grafana dashboard
- Main grid shows the higher-resolution `actual_float`; `AC Voltage` and `DC Bus Voltage` sit together; EEV Opening Steps ends a three-card row.
- New "Compressor Frequency (extended)" row holds `actual_int`, indoor/outdoor target, and outdoor control.
- Telegraf needs no change (it forwards every `sensors` field).

## Verification
`esphome compile example_midea_telemetry.yaml` succeeds.

## ⚠️ Breaking
The `compressor_frequency_target` / `compressor_frequency_actual` keys are renamed — device YAML must be updated, and historical InfluxDB data keeps the old field names. Milestone v0.5.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)