### PR TITLE
Add IPM Temperature panel to the Grafana dashboard (issue #38)

### DIFF
--- a/influxdb-grafana/grafana/dashboards/midea-telemetry.json
+++ b/influxdb-grafana/grafana/dashboards/midea-telemetry.json
@@ -957,6 +957,49 @@
       ]
     },
     {
+      "id": 26,
+      "type": "timeseries",
+      "title": "IPM Temperature",
+      "datasource": { "type": "influxdb", "uid": "midea-influxdb" },
+      "gridPos": { "h": 8, "w": 6, "x": 18, "y": 22 },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "fahrenheit",
+          "decimals": 1,
+          "color": { "mode": "fixed", "fixedColor": "red" },
+          "custom": { "drawStyle": "line", "lineInterpolation": "linear", "lineWidth": 1, "fillOpacity": 12, "gradientMode": "opacity", "showPoints": "never", "spanNulls": true }
+        },
+        "overrides": [
+          {
+            "matcher": { "id": "byFrameRefID", "options": "Z" },
+            "properties": [
+              { "id": "custom.hideFrom", "value": { "legend": true, "tooltip": true, "viz": false } },
+              { "id": "custom.lineWidth", "value": 0 },
+              { "id": "custom.fillOpacity", "value": 0 },
+              { "id": "custom.showPoints", "value": "never" },
+              { "id": "color", "value": { "mode": "fixed", "fixedColor": "rgba(0,0,0,0)" } }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull", "min", "max"] },
+        "tooltip": { "mode": "single", "sort": "none" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "influxdb", "uid": "midea-influxdb" },
+          "refId": "A",
+          "query": "from(bucket: \"${bucket}\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"midea\")\n  |> filter(fn: (r) => r._field == \"ipm_temperature\")\n  |> filter(fn: (r) => r.device == \"${device}\")\n  |> map(fn: (r) => ({ r with _value: r._value * 1.8 + 32.0 }))\n  |> drop(columns: [\"url\", \"device\"])\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)"
+        },
+        {
+          "datasource": { "type": "influxdb", "uid": "midea-influxdb" },
+          "refId": "Z",
+          "query": "import \"array\"\narray.from(rows: [{_time: v.timeRangeStart, _value: 0.0}, {_time: v.timeRangeStop, _value: 0.0}])\n  |> filter(fn: (r) => \"${ymin}\" == \"0\")"
+        }
+      ]
+    },
+    {
       "id": 18,
       "type": "timeseries",
       "title": "DC Bus Voltage",


### PR DESCRIPTION
Closes #38.

## What

Adds an **IPM Temperature** timeseries panel to `influxdb-grafana/grafana/dashboards/midea-telemetry.json`, in the free slot at `x:18, y:22` — directly next to **EEV Opening Steps**, in the same row as Current Draw and Compressor Discharge Temperature.

## Why

`ipm_temperature` is already decoded by the component (`0x01[4]`, NTC β-model) and exposed on `/json`, and Telegraf ingests the whole `sensors` object, so the field has been landing in InfluxDB all along — there was just no panel, so it was only reachable by querying InfluxDB by hand. `influxdb-grafana/README.md` already described the dashboard as covering "discharge & IPM temps", which this makes true.

## Details

The panel is modelled on the existing Compressor Discharge Temperature panel (id 6), the other temperature series of the same kind:

- `unit: fahrenheit`, `decimals: 1`, same `map()` C→F conversion in the Flux query
- panel `id: 26` (next free; previous max was 25)
- `fixedColor: red` — the remaining unused colour in the palette, distinct from discharge's pink
- invisible refId `Z` zero-anchor series retained, so the **Y-Axis Scale** variable (0-max vs min-max, #30) works on this panel too
- identical legend (`table` with `lastNotNull`/`min`/`max`) and tooltip options

No firmware, `sensor.py`, Telegraf, or docs changes — the field is already ingested and already documented.

## Verification

- JSON parses; the new panel is structurally identical to the discharge panel apart from `id`, `title`, `gridPos`, colour, and the field name in the query.
- Checked the full panel grid for overlaps — no collisions; `x:18, y:22` was genuinely free (DC Bus Voltage above it ends at y:21, the extended-frequency row starts at y:30).
- Not rendered in a live Grafana: Docker isn't running on this machine, so the panel has not been visually confirmed against real data.