### PR TITLE
Annotate parameters with Midea service-manual codes (issue #43)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,28 +8,30 @@ It supports a variety of brands including MRCOOL, Cooper&Hunter, Pioneer, and Se
 
 ## Supported Sensors
 
-The following sensors are currently supported:
+The following sensors are currently supported. `Code` is the two-letter parameter code the Midea
+service manuals use for the same value, so a reading here can be matched against the one the unit
+shows on its own diagnostic display; `—` means the manuals define no code for that value.
 
-| Sensor | Unit | Bytes | Mapping |
-|---|---|---|---|
-| `indoor_ambient_temperature` | °C | 0x00[2] | NTC β-model ¹ |
-| `indoor_coil_temperature` | °C | 0x00[3] | NTC β-model ¹ |
-| `outdoor_ambient_temperature` | °C | 0x00[5] | NTC β-model ¹ |
-| `outdoor_coil_temperature` | °C | 0x00[4] | NTC β-model ¹ |
-| `discharge_temperature` | °C | 0x00[6] | Steinhart–Hart ² |
-| `ipm_temperature` | °C | 0x01[4] | NTC β-model ¹ |
-| `operating_mode` | raw | 0x02[8] | `b` |
-| `compressor_frequency_indoor_target` | Hz | 0x04[8] | `b` |
-| `compressor_frequency_outdoor_target` | Hz | 0x02[2] | `b` |
-| `compressor_frequency_actual_int` | Hz | 0x02[3] | `b` |
-| `compressor_frequency_actual_float` | Hz | 0x02[3] + 0x05[2] | `b₀₂₋₃ + b₀₅₋₂ / 100` |
-| `compressor_frequency_outdoor_control` | Hz | 0x04[7] | `b` |
-| `outdoor_fan_speed` | raw | 0x00[7+8] | `b₇ \| b₈ << 8` (uint16 LE) |
-| `eev_steps` | raw | 0x01[5+6] | `b₅ \| b₆ << 8` (uint16 LE) |
-| `indoor_setpoint` | °C | 0x01[7] | `b < 50 ? b : (b − 50) / 2` ³ |
-| `input_voltage` | V | 0x01[3] | `⌊b · 32/25 + 40⌋` |
-| `current_draw` | A | 0x01[2] | `0.117 · b + 0.92` ⁴ |
-| `dc_bus_voltage` | V | 0x03[6] | `round(b · 59/32 − 1)` |
+| Code | Sensor | Unit | Bytes | Mapping |
+|---|---|---|---|---|
+| TT | `indoor_setpoint` | °C | 0x01[7] | `b < 50 ? b : (b − 50) / 2` ³ |
+| T1 | `indoor_ambient_temperature` | °C | 0x00[2] | NTC β-model ¹ |
+| T2 | `indoor_coil_temperature` | °C | 0x00[3] | NTC β-model ¹ |
+| T3 | `outdoor_coil_temperature` | °C | 0x00[4] | NTC β-model ¹ |
+| T4 | `outdoor_ambient_temperature` | °C | 0x00[5] | NTC β-model ¹ |
+| TP | `discharge_temperature` | °C | 0x00[6] | Steinhart–Hart ² |
+| — | `ipm_temperature` | °C | 0x01[4] | NTC β-model ¹ |
+| — | `operating_mode` | raw | 0x02[8] | `b` |
+| oT | `compressor_frequency_indoor_target` | Hz | 0x04[8] | `b` |
+| FT | `compressor_frequency_outdoor_target` | Hz | 0x02[2] | `b` |
+| Fr | `compressor_frequency_actual_int` | Hz | 0x02[3] | `b` |
+| Fr | `compressor_frequency_actual_float` | Hz | 0x02[3] + 0x05[2] | `b₀₂₋₃ + b₀₅₋₂ / 100` |
+| — | `compressor_frequency_outdoor_control` | Hz | 0x04[7] | `b` |
+| Pr | `outdoor_fan_speed` | raw | 0x00[7+8] | `b₇ \| b₈ << 8` (uint16 LE) |
+| Lr | `eev_steps` | raw | 0x01[5+6] | `b₅ \| b₆ << 8` (uint16 LE) |
+| dL | `current_draw` | A | 0x01[2] | `0.117 · b + 0.92` ⁴ |
+| Ac | `input_voltage` | V | 0x01[3] | `⌊b · 32/25 + 40⌋` |
+| Uo | `dc_bus_voltage` | V | 0x03[6] | `round(b · 59/32 − 1)` |
 
 Where `b` is the raw byte value.
 
@@ -47,6 +49,10 @@ T = 1 / (2.873×10⁻³ + 2.491×10⁻⁴ · L + 9.74×10⁻⁷ · L³) − 273.
 ³ Two OEM encodings, told apart by range (a real set-point is ~16–32 °C): whole-degree (16–32) or half-degree +50 (82–114).
 
 ⁴ The byte only carries a meaningful current while the compressor runs. When it is stopped (unit OFF or FAN ONLY) the byte sits at a per-unit floor (3 on the 115V MRCOOL, 0 on the 220V Cooper & Hunter) that the formula would misread as ~1 A, so `current_draw` reports the ~0.2 A standby baseline measured with a clamp meter whenever `compressor_frequency_actual_int` (response 2, byte 3) is 0.
+
+Two documented codes have no sensor here: `Ir` (indoor fan speed) and `Hu` (humidity), neither of which
+appears in the frames this component decodes — `Hu` also requires a humidity sensor most units lack.
+The manuals call `Lr` *EXV* opening steps; `eev_steps` is the same value under the more common spelling.
 
 `operating_mode` is a raw integer code:
 

--- a/influxdb-grafana/README.md
+++ b/influxdb-grafana/README.md
@@ -97,7 +97,7 @@ device — for the last *N* days:
 exports/2025-08-30T09-14-02/
 ├── manifest.json                  # panel → file, columns, and the Flux run
 ├── bedroom/
-│   ├── indoor-temperature.csv     # time,indoor_ambient_temperature
+│   ├── t1-indoor-temperature.csv  # time,indoor_ambient_temperature
 │   ├── mode-set-point.csv         # multi-target panels get one column each
 │   └── 0x00-2.csv                 # raw-byte explorer charts too
 └── garage/…

--- a/influxdb-grafana/grafana/dashboards/midea-telemetry.json
+++ b/influxdb-grafana/grafana/dashboards/midea-telemetry.json
@@ -440,7 +440,7 @@
     {
       "id": 3,
       "type": "timeseries",
-      "title": "Set Point History",
+      "title": "[TT] Set Point History",
       "datasource": { "type": "influxdb", "uid": "midea-influxdb" },
       "gridPos": { "h": 6, "w": 6, "x": 18, "y": 0 },
       "fieldConfig": {
@@ -484,7 +484,7 @@
     {
       "id": 1,
       "type": "timeseries",
-      "title": "Indoor Temperature",
+      "title": "[T1] Indoor Temperature",
       "datasource": { "type": "influxdb", "uid": "midea-influxdb" },
       "gridPos": { "h": 8, "w": 6, "x": 0, "y": 6 },
       "fieldConfig": {
@@ -527,7 +527,7 @@
     {
       "id": 2,
       "type": "timeseries",
-      "title": "Indoor Coil Temperature",
+      "title": "[T2] Indoor Coil Temperature",
       "datasource": { "type": "influxdb", "uid": "midea-influxdb" },
       "gridPos": { "h": 8, "w": 6, "x": 6, "y": 6 },
       "fieldConfig": {
@@ -570,7 +570,7 @@
     {
       "id": 8,
       "type": "timeseries",
-      "title": "Compressor Frequency (actual, int)",
+      "title": "[Fr] Compressor Frequency (actual, int)",
       "datasource": { "type": "influxdb", "uid": "midea-influxdb" },
       "gridPos": { "h": 8, "w": 6, "x": 0, "y": 31 },
       "fieldConfig": {
@@ -613,7 +613,7 @@
     {
       "id": 10,
       "type": "timeseries",
-      "title": "Outdoor fan speed",
+      "title": "[Pr] Outdoor fan speed",
       "datasource": { "type": "influxdb", "uid": "midea-influxdb" },
       "gridPos": { "h": 8, "w": 6, "x": 18, "y": 6 },
       "fieldConfig": {
@@ -657,7 +657,7 @@
     {
       "id": 4,
       "type": "timeseries",
-      "title": "Outdoor Temperature",
+      "title": "[T4] Outdoor Temperature",
       "datasource": { "type": "influxdb", "uid": "midea-influxdb" },
       "gridPos": { "h": 8, "w": 6, "x": 0, "y": 14 },
       "fieldConfig": {
@@ -700,7 +700,7 @@
     {
       "id": 5,
       "type": "timeseries",
-      "title": "Outdoor Coil Temperature",
+      "title": "[T3] Outdoor Coil Temperature",
       "datasource": { "type": "influxdb", "uid": "midea-influxdb" },
       "gridPos": { "h": 8, "w": 6, "x": 6, "y": 14 },
       "fieldConfig": {
@@ -743,7 +743,7 @@
     {
       "id": 7,
       "type": "timeseries",
-      "title": "Compressor Frequency (outdoor target)",
+      "title": "[FT] Compressor Frequency (outdoor target)",
       "datasource": { "type": "influxdb", "uid": "midea-influxdb" },
       "gridPos": { "h": 8, "w": 6, "x": 12, "y": 31 },
       "fieldConfig": {
@@ -786,7 +786,7 @@
     {
       "id": 12,
       "type": "timeseries",
-      "title": "Current Draw",
+      "title": "[dL] Current Draw",
       "datasource": { "type": "influxdb", "uid": "midea-influxdb" },
       "gridPos": { "h": 8, "w": 6, "x": 0, "y": 22 },
       "fieldConfig": {
@@ -830,7 +830,7 @@
     {
       "id": 11,
       "type": "timeseries",
-      "title": "AC Voltage",
+      "title": "[Ac] AC Voltage",
       "datasource": { "type": "influxdb", "uid": "midea-influxdb" },
       "gridPos": { "h": 8, "w": 6, "x": 12, "y": 14 },
       "fieldConfig": {
@@ -873,7 +873,7 @@
     {
       "id": 6,
       "type": "timeseries",
-      "title": "Compressor Discharge Temperature",
+      "title": "[TP] Compressor Discharge Temperature",
       "datasource": { "type": "influxdb", "uid": "midea-influxdb" },
       "gridPos": { "h": 8, "w": 6, "x": 6, "y": 22 },
       "fieldConfig": {
@@ -916,7 +916,7 @@
     {
       "id": 9,
       "type": "timeseries",
-      "title": "EEV Opening Steps",
+      "title": "[Lr] EEV Opening Steps",
       "datasource": { "type": "influxdb", "uid": "midea-influxdb" },
       "gridPos": { "h": 8, "w": 6, "x": 12, "y": 22 },
       "fieldConfig": {
@@ -1002,7 +1002,7 @@
     {
       "id": 18,
       "type": "timeseries",
-      "title": "DC Bus Voltage",
+      "title": "[Uo] DC Bus Voltage",
       "datasource": { "type": "influxdb", "uid": "midea-influxdb" },
       "gridPos": { "h": 8, "w": 6, "x": 18, "y": 14 },
       "fieldConfig": {
@@ -1058,7 +1058,7 @@
     {
       "id": 21,
       "type": "timeseries",
-      "title": "Compressor Frequency (indoor target)",
+      "title": "[oT] Compressor Frequency (indoor target)",
       "datasource": {
         "type": "influxdb",
         "uid": "midea-influxdb"
@@ -1162,7 +1162,7 @@
     {
       "id": 22,
       "type": "timeseries",
-      "title": "Compressor Frequency (actual, float)",
+      "title": "[Fr] Compressor Frequency (actual, float)",
       "datasource": {
         "type": "influxdb",
         "uid": "midea-influxdb"


### PR DESCRIPTION
Closes #43.

The service manuals identify each parameter by a two-letter code, and the unit shows those codes on its own diagnostic display. Nothing here connected them to sensor names, so checking a reading on the display against the same reading in Grafana meant inferring the pairing from the label text.

## README

A `Code` column on the sensor table, covering all 18 sensors:

| Code | Sensor | | Code | Sensor |
|---|---|---|---|---|
| T1 | `indoor_ambient_temperature` | | oT | `compressor_frequency_indoor_target` |
| T2 | `indoor_coil_temperature` | | Fr | `compressor_frequency_actual_int` |
| T3 | `outdoor_coil_temperature` | | Fr | `compressor_frequency_actual_float` |
| T4 | `outdoor_ambient_temperature` | | Pr | `outdoor_fan_speed` |
| TT | `indoor_setpoint` | | Lr | `eev_steps` |
| TP | `discharge_temperature` | | Ac | `input_voltage` |
| FT | `compressor_frequency_outdoor_target` | | dL | `current_draw` |
| — | `ipm_temperature` | | Uo | `dc_bus_voltage` |
| — | `operating_mode` | | — | `compressor_frequency_outdoor_control` |

Three sensors have no documented code; those cells carry an em dash rather than sitting empty, so "no code exists" is distinguishable from an oversight.

Two documented codes have no sensor here — `Ir` (indoor fan speed), absent from the frames this component decodes, and `Hu` (humidity), which needs a sensor most units lack. Both are named in the README so the gap reads as deliberate. The manuals call `Lr` *EXV* opening steps; `eev_steps` is the same value under the commoner spelling, also noted.

## Dashboard

The code is prefixed onto the 15 single-parameter panel titles — `Current Draw` → `[dL] Current Draw`.

Left alone:

- the four multi-target stat cards (Mode / Set Point, Indoor / Outdoor Temperature, Compressor Frequency, Current / Fan Speed), where no single code applies;
- the rows and the raw-byte explorer panels;
- the three panels whose parameter has no code, which stay unprefixed rather than carry a `[--]` placeholder.

## Knock-on effects

**Export filenames change.** `tools/export-dashboard-data.py` slugifies panel titles into filenames, so `current-draw.csv` is now `dl-current-draw.csv` across the 15 retitled panels. Checked for slug collisions — none, including the two `[Fr]` panels, which stay distinct via their `int`/`float` suffixes. The example filename in `influxdb-grafana/README.md` is updated to match.

**Home Assistant entity names are deliberately untouched.** The `name:` fields in `example_midea_telemetry.yaml` become entity IDs, so prefixing them would break existing users' dashboards and history.

## Verification

No firmware or decoding changes — labels and documentation only. The dashboard JSON still parses, and `export-dashboard-data.py --dry-run` enumerates every panel with no unsubstituted variables. Not rendered against a live Grafana.

One judgement call worth a second opinion: the `FT` → `compressor_frequency_outdoor_target` and `oT` → `compressor_frequency_indoor_target` pairings follow the manuals' own wording ("calculated by indoor" for `oT`), but were not confirmed against a unit's service display. If `FT` turns out to name what this repo calls `compressor_frequency_outdoor_control`, those three rows shift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)