### PR TITLE
Remove ipm_temperature (issue #45)

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,6 @@ shows on its own diagnostic display; `—` means the manuals define no code for 
 | T3 | `outdoor_coil_temperature` | °C | 0x00[4] | NTC β-model ¹ |
 | T4 | `outdoor_ambient_temperature` | °C | 0x00[5] | NTC β-model ¹ |
 | TP | `discharge_temperature` | °C | 0x00[6] | Steinhart–Hart ² |
-| — | `ipm_temperature` | °C | 0x01[4] | NTC β-model ¹ |
 | — | `operating_mode` | raw | 0x02[8] | `b` |
 | oT | `compressor_frequency_indoor_target` | Hz | 0x04[8] | `b` |
 | FT | `compressor_frequency_outdoor_target` | Hz | 0x02[2] | `b` |

--- a/UART-comparison.md
+++ b/UART-comparison.md
@@ -11,7 +11,6 @@ The UART port is more easily accessible than the diagnostic port on the ODU, whi
 | `outdoor_ambient_temperature` | ✅ | ✅ | |
 | `outdoor_coil_temperature`    | ✅ | ✅ | |
 | `discharge_temperature`       | ✅ | ❌ | |
-| `ipm_temperature`             | ❌ | ❌ | |
 | `operating_mode`              | ✅ | ✅ | |
 | `compressor_frequency_outdoor_target`     | ✅ | ❌ | |
 | `compressor_frequency_actual_int` | ✅ | ✅ | |

--- a/components/midea_telemetry/midea_telemetry.cpp
+++ b/components/midea_telemetry/midea_telemetry.cpp
@@ -125,7 +125,6 @@ static const MappedParam MAPPED_PARAMS[] = {
     {"outdoor_ambient_temperature",               {{0x00, 5}},            1, [](const uint8_t f[][FRAME_SIZE]) { return ntc_temp(f[0x00][5]); }},
     {"outdoor_coil_temperature",                  {{0x00, 4}},            1, [](const uint8_t f[][FRAME_SIZE]) { return ntc_temp(f[0x00][4]); }},
     {"discharge_temperature",                     {{0x00, 6}},            1, [](const uint8_t f[][FRAME_SIZE]) { return discharge_temp(f[0x00][6]); }},
-    {"ipm_temperature",                           {{0x01, 4}},            1, [](const uint8_t f[][FRAME_SIZE]) { return ntc_temp(f[0x01][4]); }},
     {"operating_mode",                            {{0x02, 8}},            1, [](const uint8_t f[][FRAME_SIZE]) { return (float) f[0x02][8]; }},
     {"compressor_frequency_indoor_target",        {{0x04, 8}},            1, [](const uint8_t f[][FRAME_SIZE]) { return (float) f[0x04][8]; }},
     {"compressor_frequency_outdoor_target",       {{0x02, 2}},            1, [](const uint8_t f[][FRAME_SIZE]) { return (float) f[0x02][2]; }},
@@ -325,7 +324,6 @@ void MideaTelemetry::update() {
       this->outdoor_ambient_temperature_sensor_,
       this->outdoor_coil_temperature_sensor_,
       this->discharge_temperature_sensor_,
-      this->ipm_temperature_sensor_,
       this->operating_mode_sensor_,
       this->compressor_frequency_indoor_target_sensor_,
       this->compressor_frequency_outdoor_target_sensor_,
@@ -355,7 +353,6 @@ void MideaTelemetry::dump_config() {
   LOG_SENSOR("  ", "Outdoor ambient temperature", this->outdoor_ambient_temperature_sensor_);
   LOG_SENSOR("  ", "Outdoor coil temperature", this->outdoor_coil_temperature_sensor_);
   LOG_SENSOR("  ", "Compressor discharge temperature", this->discharge_temperature_sensor_);
-  LOG_SENSOR("  ", "IPM temperature", this->ipm_temperature_sensor_);
   LOG_SENSOR("  ", "Operating mode", this->operating_mode_sensor_);
   LOG_SENSOR("  ", "Compressor frequency (indoor target)", this->compressor_frequency_indoor_target_sensor_);
   LOG_SENSOR("  ", "Compressor frequency (outdoor target)", this->compressor_frequency_outdoor_target_sensor_);

--- a/components/midea_telemetry/midea_telemetry.h
+++ b/components/midea_telemetry/midea_telemetry.h
@@ -46,7 +46,6 @@ class MideaTelemetry : public PollingComponent
   void set_outdoor_ambient_temperature_sensor(sensor::Sensor *s) { this->outdoor_ambient_temperature_sensor_ = s; }
   void set_outdoor_coil_temperature_sensor(sensor::Sensor *s) { this->outdoor_coil_temperature_sensor_ = s; }
   void set_discharge_temperature_sensor(sensor::Sensor *s) { this->discharge_temperature_sensor_ = s; }
-  void set_ipm_temperature_sensor(sensor::Sensor *s) { this->ipm_temperature_sensor_ = s; }
   void set_operating_mode_sensor(sensor::Sensor *s) { this->operating_mode_sensor_ = s; }
   void set_compressor_frequency_indoor_target_sensor(sensor::Sensor *s) { this->compressor_frequency_indoor_target_sensor_ = s; }
   void set_compressor_frequency_outdoor_target_sensor(sensor::Sensor *s) { this->compressor_frequency_outdoor_target_sensor_ = s; }
@@ -85,7 +84,6 @@ class MideaTelemetry : public PollingComponent
   sensor::Sensor *outdoor_ambient_temperature_sensor_{nullptr};
   sensor::Sensor *outdoor_coil_temperature_sensor_{nullptr};
   sensor::Sensor *discharge_temperature_sensor_{nullptr};
-  sensor::Sensor *ipm_temperature_sensor_{nullptr};
   sensor::Sensor *operating_mode_sensor_{nullptr};
   sensor::Sensor *compressor_frequency_indoor_target_sensor_{nullptr};
   sensor::Sensor *compressor_frequency_outdoor_target_sensor_{nullptr};

--- a/components/midea_telemetry/sensor.py
+++ b/components/midea_telemetry/sensor.py
@@ -35,7 +35,6 @@ SENSORS = {
     "outdoor_ambient_temperature": _temperature_schema(1),
     "outdoor_coil_temperature": _temperature_schema(1),
     "discharge_temperature": _temperature_schema(0),
-    "ipm_temperature": _temperature_schema(1),
     "operating_mode": sensor.sensor_schema(
         icon="mdi:state-machine",
         state_class=STATE_CLASS_MEASUREMENT,

--- a/example_midea_telemetry.yaml
+++ b/example_midea_telemetry.yaml
@@ -49,8 +49,6 @@ sensor:
       name: Outdoor coil temperature
     discharge_temperature:
       name: Compressor discharge temperature
-    ipm_temperature:
-      name: IPM temperature
     operating_mode:
       name: Operating mode
     compressor_frequency_indoor_target:

--- a/influxdb-grafana/README.md
+++ b/influxdb-grafana/README.md
@@ -70,7 +70,7 @@ and Grafana renders a provisioned dashboard on top — no Home Assistant require
 | Dashboard | `grafana/dashboards/midea-telemetry.json` |
 
 The dashboard groups every field from the [Fields table](../README.md#fields):
-coil/ambient temps, discharge & IPM temps, the compressor-frequency family
+coil/ambient temps, discharge temp, the compressor-frequency family
 (indoor/outdoor target, actual as int and float, and outdoor control —
 under the "Compressor Frequency (extended)" row at the bottom), outdoor fan
 speed & EEV steps, input/DC-bus voltage, current draw, and set-point/operating

--- a/influxdb-grafana/grafana/dashboards/midea-telemetry.json
+++ b/influxdb-grafana/grafana/dashboards/midea-telemetry.json
@@ -957,49 +957,6 @@
       ]
     },
     {
-      "id": 26,
-      "type": "timeseries",
-      "title": "IPM Temperature",
-      "datasource": { "type": "influxdb", "uid": "midea-influxdb" },
-      "gridPos": { "h": 8, "w": 6, "x": 18, "y": 22 },
-      "fieldConfig": {
-        "defaults": {
-          "unit": "fahrenheit",
-          "decimals": 1,
-          "color": { "mode": "fixed", "fixedColor": "red" },
-          "custom": { "drawStyle": "line", "lineInterpolation": "linear", "lineWidth": 1, "fillOpacity": 12, "gradientMode": "opacity", "showPoints": "never", "spanNulls": true }
-        },
-        "overrides": [
-          {
-            "matcher": { "id": "byFrameRefID", "options": "Z" },
-            "properties": [
-              { "id": "custom.hideFrom", "value": { "legend": true, "tooltip": true, "viz": false } },
-              { "id": "custom.lineWidth", "value": 0 },
-              { "id": "custom.fillOpacity", "value": 0 },
-              { "id": "custom.showPoints", "value": "never" },
-              { "id": "color", "value": { "mode": "fixed", "fixedColor": "rgba(0,0,0,0)" } }
-            ]
-          }
-        ]
-      },
-      "options": {
-        "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull", "min", "max"] },
-        "tooltip": { "mode": "single", "sort": "none" }
-      },
-      "targets": [
-        {
-          "datasource": { "type": "influxdb", "uid": "midea-influxdb" },
-          "refId": "A",
-          "query": "from(bucket: \"${bucket}\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"midea\")\n  |> filter(fn: (r) => r._field == \"ipm_temperature\")\n  |> filter(fn: (r) => r.device == \"${device}\")\n  |> map(fn: (r) => ({ r with _value: r._value * 1.8 + 32.0 }))\n  |> drop(columns: [\"url\", \"device\"])\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)"
-        },
-        {
-          "datasource": { "type": "influxdb", "uid": "midea-influxdb" },
-          "refId": "Z",
-          "query": "import \"array\"\narray.from(rows: [{_time: v.timeRangeStart, _value: 0.0}, {_time: v.timeRangeStop, _value: 0.0}])\n  |> filter(fn: (r) => \"${ymin}\" == \"0\")"
-        }
-      ]
-    },
-    {
       "id": 18,
       "type": "timeseries",
       "title": "[Uo] DC Bus Voltage",

--- a/tools/logviewer.html
+++ b/tools/logviewer.html
@@ -254,7 +254,6 @@ const KNOWN_BYTES = {
   0x01: {
     2: 'Current draw',
     3: 'Input voltage',
-    4: 'IPM temperature',
     5: 'EEV opening steps (low byte)',
     6: 'EEV opening steps (high byte)',
     7: 'Indoor set-point',


### PR DESCRIPTION
Closes #45.

## Why

The component decoded `0x01[4]` through the NTC β-model and published it as `ipm_temperature` — an ESPHome sensor, a `/json` key, an InfluxDB field, a Home Assistant entity, a Grafana panel (#39), and a byte label in the log viewer.

Nothing establishes that `0x01[4]` carries the IPM (power-module) temperature. The byte yields plausible-looking degrees under the NTC curve, and that is the whole of the evidence. `UART-comparison.md` has meanwhile marked the sensor absent in the **Diagnostic Port** column — contradicting the component that decodes it from that very port.

A named, unit-bearing sensor resting on a guess is worse than no sensor: it invites people to read and act on °C values that may mean something else entirely.

**Nothing observable is lost.** The raw-byte explorer already charts `0x01[4]` (`0x01` and `4` are both in its `frame`/`byte` variable lists), so the data needed to settle the mapping later is still collected and still visible. Only the interpretation goes away — and #39 is there to reinstate it from, if the mapping is ever confirmed against a service display.

## What changed

**Component** — field table, `sensors[]` array and `log_config` in `midea_telemetry.cpp`; setter and member in `midea_telemetry.h`; schema entry in `sensor.py`; the example YAML block. `MAPPED_PARAMS` and `sensors[]` both shrink to 17 in the same order, so the `static_assert` pairing them still holds.

**Grafana** — panel id 26 deleted, **slot deliberately left empty**. Current Draw (`x:0`), Compressor Discharge Temperature (`x:6`) and EEV Opening Steps (`x:12`) keep their `gridPos`, so the row ends with a six-column gap rather than reflowing panels whose position readers have learned.

**Docs** — the README sensor row, the `UART-comparison.md` row, the "discharge & IPM temps" phrasing in `influxdb-grafana/README.md`, and the `0x01[4]` label in `tools/logviewer.html`, which now renders unlabeled like any other unmapped byte.

## Breaking change

An `ipm_temperature:` block in an existing user's YAML becomes an ESPHome validation error rather than being silently ignored:

```
[ipm_temperature] is an invalid option for [sensor.midea_telemetry].
Did you mean [discharge_temperature], [indoor_coil_temperature], ...?
```

Probably worth a line in the release notes.

No Telegraf change is needed — `gen-telegraf-conf.sh` turns every numeric leaf of `/json` into a field, so the field stops being written once the firmware stops emitting it. Historical points already in InfluxDB are untouched; removing the panel deletes no data.

## Verification

- `esphome config example_midea_telemetry.yaml` — passes.
- Same, with an `ipm_temperature:` block re-added — correctly rejected with the invalid-option error above.
- `esphome compile example_midea_telemetry.yaml` — builds clean, so the `static_assert` holds.
- Dashboard JSON parses; 24 panels remain and the three survivors in that row keep their original `gridPos`.

Not rendered against a live Grafana.

🤖 Generated with [Claude Code](https://claude.com/claude-code)