### PR TITLE
Optionally expose raw frame bytes as Home Assistant sensors (issue #47)

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,31 @@ The manuals call `Lr` *EXV* opening steps; `eev_steps` is the same value under t
 
 Map it to text in Home Assistant with a template sensor. The bundled [Grafana dashboard](influxdb-grafana/) already renders it as a labeled card plus a mode-history timeline.
 
+### Raw frame bytes (optional)
+
+The table above is the *decoded* view. The unit also returns bytes nobody has mapped yet, and those differ between models — so if your unit does something the decoded sensors do not explain, the raw bytes are where to look.
+
+Bytes 2–8 of all seven response frames (49 in total) can each be published to Home Assistant as-is, with no interpretation. They are **off by default**; uncomment the ones you want in the `sensor:` block:
+
+```yaml
+sensor:
+  - platform: midea_telemetry
+    indoor_ambient_temperature:
+      name: Indoor ambient temperature
+
+    # raw_0x01_3: { name: "Raw 0x01[3]" }
+    raw_0x01_4: { name: "Raw 0x01[4]" }     # enabled
+    # raw_0x01_5: { name: "Raw 0x01[5]" }
+```
+
+[`example_midea_telemetry.yaml`](example_midea_telemetry.yaml) lists all 49 commented out, grouped by frame, ready to uncomment.
+
+The key is `raw_0x<frame>_<byte>`, matching the `midea_raw` InfluxDB field names (`0x01_4`) so the same byte is recognisable in Home Assistant and in Grafana. Bytes 0, 1 and 9 are framing — header, response type, checksum — and are not offered.
+
+They behave like the decoded sensors: `state_class: measurement`, no unit (a byte is not a quantity), and **unavailable** rather than frozen when the frame carrying them stops arriving. They are published under Home Assistant's *Diagnostic* category, so they stay off the main device card.
+
+**Enable only the bytes you are actually investigating.** All 49 publish on every poll, which is a lot of rows for Home Assistant's recorder database. For sustained observation across days, the [Grafana byte explorer](influxdb-grafana/RAW-BYTES.md) is the better tool — it charts the same bytes without touching Home Assistant at all. The firmware cost is small either way: nothing when none are enabled, about 1.7 KB of RAM and 3.4 KB of flash with all 49 on.
+
 ## Prior Art
 
 I've documented the diagnostic bus protocol in great detail on Medium: [Reverse Engineering Midea's ODU Diagnostic Port](https://medium.com/@florian.mckee/reverse-engineering-mideas-odu-diagnostic-port-af603e159053). The firmware in this repository is based on those findings. Start there if you want to understand the protocol; the byte mappings and conversion formulas in the [Supported Sensors](#supported-sensors) table come straight from it.

--- a/components/midea_telemetry/midea_telemetry.cpp
+++ b/components/midea_telemetry/midea_telemetry.cpp
@@ -341,6 +341,12 @@ void MideaTelemetry::update() {
                 "sensors[] must line up 1:1 with MAPPED_PARAMS");
   for (size_t i = 0; i < NUM_MAPPED_PARAMS; i++)
     publish(sensors[i], param_fresh(MAPPED_PARAMS[i], fresh), MAPPED_PARAMS[i].decode(frames));
+
+  // Opt-in raw bytes (issue #47). Same staleness rule as the decoded sensors:
+  // a byte whose frame stopped arriving goes unavailable rather than freezing.
+  for (size_t f = 0; f < NUM_RESPONSE_TYPES; f++)
+    for (size_t b = RAW_BYTE_FIRST; b <= RAW_BYTE_LAST; b++)
+      publish(this->raw_byte_sensors_[f][b], fresh[f], (float) frames[f][b]);
 }
 
 void MideaTelemetry::dump_config() {
@@ -365,6 +371,16 @@ void MideaTelemetry::dump_config() {
   LOG_SENSOR("  ", "Input voltage", this->input_voltage_sensor_);
   LOG_SENSOR("  ", "Current draw", this->current_draw_sensor_);
   LOG_SENSOR("  ", "DC bus voltage", this->dc_bus_voltage_sensor_);
+
+  // Summarised rather than logged one LOG_SENSOR line per byte: all 49 enabled
+  // would bury the rest of the config dump.
+  size_t raw_enabled = 0;
+  for (size_t f = 0; f < NUM_RESPONSE_TYPES; f++)
+    for (size_t b = RAW_BYTE_FIRST; b <= RAW_BYTE_LAST; b++)
+      if (this->raw_byte_sensors_[f][b] != nullptr)
+        raw_enabled++;
+  ESP_LOGCONFIG(TAG, "  Raw byte sensors: %u of %u enabled", (unsigned) raw_enabled,
+                (unsigned) (NUM_RESPONSE_TYPES * (RAW_BYTE_LAST - RAW_BYTE_FIRST + 1)));
 }
 
 #ifdef USE_MIDEA_TELEMETRY_JSON

--- a/components/midea_telemetry/midea_telemetry.h
+++ b/components/midea_telemetry/midea_telemetry.h
@@ -20,6 +20,11 @@ namespace midea_telemetry {
 static const size_t FRAME_SIZE = 10;
 static const size_t NUM_RESPONSE_TYPES = 7;
 
+// Bytes 0/1/9 of a frame are framing (header, response type, checksum); only
+// 2-8 carry telemetry. Same window the raw-byte Grafana explorer charts.
+static const size_t RAW_BYTE_FIRST = 2;
+static const size_t RAW_BYTE_LAST = 8;
+
 // Drives the two-wire diagnostic bus on the outdoor inverter board the same
 // way Midea's handheld inverter tester does: 80-bit frames, LSB-first, with
 // the tester (us) driving the clock in both directions. The bit-banging runs
@@ -59,6 +64,13 @@ class MideaTelemetry : public PollingComponent
   void set_current_draw_sensor(sensor::Sensor *s) { this->current_draw_sensor_ = s; }
   void set_dc_bus_voltage_sensor(sensor::Sensor *s) { this->dc_bus_voltage_sensor_ = s; }
 
+  // Opt-in per byte (issue #47): publishes a frame byte as-is, with no
+  // interpretation, so unknown bytes can be watched from Home Assistant
+  // without the InfluxDB/Grafana stack.
+  void set_raw_byte_sensor(uint8_t frame, uint8_t byte, sensor::Sensor *s) {
+    this->raw_byte_sensors_[frame][byte] = s;
+  }
+
 #ifdef USE_MIDEA_TELEMETRY_JSON
   // Serves all mapped parameters and the raw frames as JSON at /json on the
   // ESPHome web server (see handleRequest), so everything can be read for
@@ -96,6 +108,9 @@ class MideaTelemetry : public PollingComponent
   sensor::Sensor *input_voltage_sensor_{nullptr};
   sensor::Sensor *current_draw_sensor_{nullptr};
   sensor::Sensor *dc_bus_voltage_sensor_{nullptr};
+
+  // [frame][byte], indexed directly rather than packed to the 49 used slots.
+  sensor::Sensor *raw_byte_sensors_[NUM_RESPONSE_TYPES][FRAME_SIZE]{};
 
 #ifdef USE_MIDEA_TELEMETRY_JSON
   bool json_endpoint_{false};

--- a/components/midea_telemetry/sensor.py
+++ b/components/midea_telemetry/sensor.py
@@ -3,6 +3,7 @@ import esphome.config_validation as cv
 from esphome.components import sensor
 from esphome.const import (
     DEVICE_CLASS_CURRENT,
+    ENTITY_CATEGORY_DIAGNOSTIC,
     DEVICE_CLASS_FREQUENCY,
     DEVICE_CLASS_TEMPERATURE,
     DEVICE_CLASS_VOLTAGE,
@@ -101,10 +102,38 @@ SENSORS = {
     ),
 }
 
+# Every response frame byte that carries telemetry, exposed as an opt-in sensor
+# so unknown bytes can be watched from Home Assistant without the
+# InfluxDB/Grafana stack (issue #47). Bytes 0/1/9 are framing (header, response
+# type, checksum). Keys mirror the `midea_raw` InfluxDB field names (`0x00_2`)
+# with a `raw_` prefix, so one byte is recognisable across both.
+NUM_RESPONSE_TYPES = 7
+RAW_BYTE_FIRST = 2
+RAW_BYTE_LAST = 8
+
+RAW_BYTE_SENSORS = {
+    f"raw_0x{frame:02x}_{byte}": (frame, byte)
+    for frame in range(NUM_RESPONSE_TYPES)
+    for byte in range(RAW_BYTE_FIRST, RAW_BYTE_LAST + 1)
+}
+
+
+def _raw_byte_schema():
+    # No unit and no device class: this is a byte, not a quantity. Diagnostic so
+    # the 49 of them stay off the main device card in Home Assistant.
+    return sensor.sensor_schema(
+        icon="mdi:hexadecimal",
+        state_class=STATE_CLASS_MEASUREMENT,
+        accuracy_decimals=0,
+        entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+    )
+
+
 CONFIG_SCHEMA = cv.Schema(
     {
         cv.GenerateID(CONF_MIDEA_TELEMETRY_ID): cv.use_id(MideaTelemetry),
         **{cv.Optional(key): schema for key, schema in SENSORS.items()},
+        **{cv.Optional(key): _raw_byte_schema() for key in RAW_BYTE_SENSORS},
     }
 )
 
@@ -115,3 +144,7 @@ async def to_code(config):
         if key in config:
             sens = await sensor.new_sensor(config[key])
             cg.add(getattr(hub, f"set_{key}_sensor")(sens))
+    for key, (frame, byte) in RAW_BYTE_SENSORS.items():
+        if key in config:
+            sens = await sensor.new_sensor(config[key])
+            cg.add(hub.set_raw_byte_sensor(frame, byte, sens))

--- a/example_midea_telemetry.yaml
+++ b/example_midea_telemetry.yaml
@@ -73,3 +73,80 @@ sensor:
       name: Current draw
     dc_bus_voltage:
       name: DC bus voltage
+
+    # ---------------------------------------------------------------------
+    # Raw frame bytes (optional, off by default)
+    #
+    # Uncomment a line to publish that byte to Home Assistant as-is, with no
+    # interpretation - useful for hunting a mapping on a unit whose bytes
+    # differ from the documented ones. They arrive as Diagnostic entities.
+    #
+    # Enable only the bytes you are actually investigating: all 49 publish on
+    # every poll, which is a lot of rows for Home Assistant's recorder.
+    # Bytes 0/1/9 are framing (header, response type, checksum), so only 2-8
+    # are offered. The same bytes drive the Grafana byte explorer, which is
+    # the better tool for long history - see influxdb-grafana/RAW-BYTES.md.
+    # ---------------------------------------------------------------------
+
+    # Response 0x00
+    # raw_0x00_2: { name: "Raw 0x00[2]" }
+    # raw_0x00_3: { name: "Raw 0x00[3]" }
+    # raw_0x00_4: { name: "Raw 0x00[4]" }
+    # raw_0x00_5: { name: "Raw 0x00[5]" }
+    # raw_0x00_6: { name: "Raw 0x00[6]" }
+    # raw_0x00_7: { name: "Raw 0x00[7]" }
+    # raw_0x00_8: { name: "Raw 0x00[8]" }
+
+    # Response 0x01
+    # raw_0x01_2: { name: "Raw 0x01[2]" }
+    # raw_0x01_3: { name: "Raw 0x01[3]" }
+    # raw_0x01_4: { name: "Raw 0x01[4]" }
+    # raw_0x01_5: { name: "Raw 0x01[5]" }
+    # raw_0x01_6: { name: "Raw 0x01[6]" }
+    # raw_0x01_7: { name: "Raw 0x01[7]" }
+    # raw_0x01_8: { name: "Raw 0x01[8]" }
+
+    # Response 0x02
+    # raw_0x02_2: { name: "Raw 0x02[2]" }
+    # raw_0x02_3: { name: "Raw 0x02[3]" }
+    # raw_0x02_4: { name: "Raw 0x02[4]" }
+    # raw_0x02_5: { name: "Raw 0x02[5]" }
+    # raw_0x02_6: { name: "Raw 0x02[6]" }
+    # raw_0x02_7: { name: "Raw 0x02[7]" }
+    # raw_0x02_8: { name: "Raw 0x02[8]" }
+
+    # Response 0x03
+    # raw_0x03_2: { name: "Raw 0x03[2]" }
+    # raw_0x03_3: { name: "Raw 0x03[3]" }
+    # raw_0x03_4: { name: "Raw 0x03[4]" }
+    # raw_0x03_5: { name: "Raw 0x03[5]" }
+    # raw_0x03_6: { name: "Raw 0x03[6]" }
+    # raw_0x03_7: { name: "Raw 0x03[7]" }
+    # raw_0x03_8: { name: "Raw 0x03[8]" }
+
+    # Response 0x04
+    # raw_0x04_2: { name: "Raw 0x04[2]" }
+    # raw_0x04_3: { name: "Raw 0x04[3]" }
+    # raw_0x04_4: { name: "Raw 0x04[4]" }
+    # raw_0x04_5: { name: "Raw 0x04[5]" }
+    # raw_0x04_6: { name: "Raw 0x04[6]" }
+    # raw_0x04_7: { name: "Raw 0x04[7]" }
+    # raw_0x04_8: { name: "Raw 0x04[8]" }
+
+    # Response 0x05
+    # raw_0x05_2: { name: "Raw 0x05[2]" }
+    # raw_0x05_3: { name: "Raw 0x05[3]" }
+    # raw_0x05_4: { name: "Raw 0x05[4]" }
+    # raw_0x05_5: { name: "Raw 0x05[5]" }
+    # raw_0x05_6: { name: "Raw 0x05[6]" }
+    # raw_0x05_7: { name: "Raw 0x05[7]" }
+    # raw_0x05_8: { name: "Raw 0x05[8]" }
+
+    # Response 0x06
+    # raw_0x06_2: { name: "Raw 0x06[2]" }
+    # raw_0x06_3: { name: "Raw 0x06[3]" }
+    # raw_0x06_4: { name: "Raw 0x06[4]" }
+    # raw_0x06_5: { name: "Raw 0x06[5]" }
+    # raw_0x06_6: { name: "Raw 0x06[6]" }
+    # raw_0x06_7: { name: "Raw 0x06[7]" }
+    # raw_0x06_8: { name: "Raw 0x06[8]" }

--- a/influxdb-grafana/RAW-BYTES.md
+++ b/influxdb-grafana/RAW-BYTES.md
@@ -11,6 +11,12 @@ unit-specific unknown bytes — from that one source. Mappings become Flux you
 can change without reflashing, and history can be recomputed when a formula
 improves.
 
+> **Just want to eyeball a byte from Home Assistant?** You do not need this
+> stack for that. The same bytes 2-8 of each frame can be published straight to
+> HA as opt-in sensors — see [Raw frame bytes](../README.md#raw-frame-bytes-optional)
+> in the main README. This page is the better route for sustained observation
+> across days, since it keeps the history out of HA's recorder.
+
 ## 1. Endpoint
 
 `/json` exposes every response frame as a per-byte decimal array (alongside the


### PR DESCRIPTION
Closes #47.

## Why

The raw frame bytes had exactly one consumer: `/json` → Telegraf → the `midea_raw` measurement → the Grafana byte explorer (#36). That is the right tool for hunting a mapping across weeks of history, but it asks you to stand up Docker, InfluxDB, Telegraf and Grafana first.

Home Assistant users saw only the decoded sensors, so every byte whose meaning is still unknown was invisible to exactly the people best placed to help identify it — someone with an unusual unit that does something the decoded sensors do not explain.

## What

Bytes **2–8 of all seven response frames** (49 values) can each be published to Home Assistant as-is, with no interpretation. Bytes 0/1/9 are framing (header, response type, checksum) and are not offered.

**Opt-in per byte, by uncommenting** — default behaviour is unchanged:

```yaml
sensor:
  - platform: midea_telemetry
    indoor_ambient_temperature:
      name: Indoor ambient temperature

    # raw_0x01_3: { name: "Raw 0x01[3]" }
    raw_0x01_4: { name: "Raw 0x01[4]" }     # enabled
    # raw_0x01_5: { name: "Raw 0x01[5]" }
```

`example_midea_telemetry.yaml` now carries all 49 commented out, grouped by frame, ready to uncomment.

The key mirrors the `midea_raw` InfluxDB field name (`0x01_4`) with a `raw_` prefix, so one byte is recognisable in both Home Assistant and Grafana; the entity name uses the `0x01[4]` notation the README and byte explorer already use.

## How

- `sensor.py` **generates** the 49 schema entries rather than listing them.
- The component takes one `set_raw_byte_sensor(frame, byte, sensor)` into a `[frame][byte]` pointer array, instead of 49 setters and 49 members.
- Publishing reuses the existing NAN-on-stale rule, so a raw entity goes **unavailable** in HA when its frame stops arriving, rather than freezing on the last value.
- `dump_config` summarises them as a count — 49 `LOG_SENSOR` lines would bury the rest of the dump.
- Each byte is a **diagnostic** entity with no unit and no device class (a byte is not a quantity), which also keeps 49 of them off the main device card.

## The cost, and why it is opt-in per byte

All 49 enabled means 49 entities publishing on every poll — a lot of rows for Home Assistant's recorder. The README says so plainly and points at the Grafana explorer as the better tool for sustained observation across days. That is also why there is no single `enable-all` flag.

Firmware cost is small either way, measured on the example config:

| | RAM | Flash |
|---|---|---|
| none enabled | 102,947 | 860,927 |
| all 49 enabled | 104,715 | 864,431 |
| **delta** | **+1,768 B** | **+3,504 B** |

## Verification

- `esphome config` passes with all 49 commented — the default is genuinely unchanged.
- With bytes uncommented, the schema resolves as expected (`icon: mdi:hexadecimal`, `accuracy_decimals: 0`, `state_class: measurement`, `entity_category: diagnostic`).
- `esphome compile` succeeds both with two bytes enabled and with all 49.
- Branch is a single commit on top of `main` at e575cb8, which already includes #46; the +280 bytes of `.bss` for the pointer array is visible against that baseline.

Not yet run against real hardware — the publish path is exercised by compilation only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
