### PR TITLE
README: restructure into decision path -> build path -> reference (issue #49)

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,20 +19,6 @@ Since Midea-made mini-splits are very similar across brands, many other units fr
 
 **Note**: I haven't had a chance to analyze the diagnostic bus on a multi-head unit yet. Supporting these units will likely require firmware enhancements beyond what's currently implemented.
 
-The wiring diagrams for the following outdoor units include the diagnostic port:
-
-| Brand | Outdoor Models | Wiring Diagram |
-|---|---| ---|
-| MRCOOL | DIY-18-HP-C-230C, DIY-24-HP-C-230C, DIY-36-HP-C-230C  | [mc-diy-4-ah-sz-sm-en-01.pdf](https://doxrepo.mrcool.com/mc-diy-4-ah-sz-sm-en-01.pdf) |
-| Pioneer | YN009GMFI22RPE, YN012GMFI22RPE, YN009GMFI20RPD, YN012GMFI20RPD, YN018GMFI20RPD, YN009AMFI22RPE, YN012AMFI22RPE, YN009AMFI20RPD, YN012AMFI20RPD, YN018GMFI22RPE, YN024GMFI22RPE, YN024GMFI20RPD, YN030GMFI20RPD, YN036GMFI20RPD  | [WYS_SM.pdf](https://www.pdhvac.com/site/downloads/WYS_SM.pdf) |
-
-The following outdoor unit models reportedly lack a diagnostic port, or their wiring diagrams show no such port:
-
-| Brand | Outdoor Model | Wiring Diagram |
-|---|---|---|
-| Pioneer | YN036GLFI19RPE | n/a |
-| Carrier | 38MARBQ24AA3 | [SG-38MARB-02.pdf](https://www.shareddocs.com/hvac/docs/1009/Public/03/SG-38MARB-02.pdf) |
-
 ## Hardware
 
 All you need is a **dual-core ESP32** and a level shifter. A dual core is required because the bus bit-banging runs in a dedicated FreeRTOS task. A full request/response cycle keeps the bus busy for ~380 ms, far too long to run on the main loop.

--- a/README.md
+++ b/README.md
@@ -6,6 +6,135 @@ It supports a variety of brands including MRCOOL, Cooper&Hunter, Pioneer, and Se
 
 ![Home Assistant Dashboard](images/ha-dashboard.png)
 
+## Compatibility
+
+The dongle has been tested successfully with the following outdoor units:
+
+| Brand | Outdoor Models |
+|---|---|
+| MRCOOL | DIY-12-HP-C-115C25 |
+| Cooper&Hunter | CH-HPR06F9-230VO, CH-N36LCU-230VO |
+
+Since Midea-made mini-splits are very similar across brands, many other units from brands like MRCOOL, Cooper&Hunter, Senville, Pioneer, Blueridge, etc. are supported as well. Check your unit's wiring diagram, or look for a diagnostic port (white 4-pin JST connector labeled `TEST`) on the control board itself, to confirm.
+
+**Note**: I haven't had a chance to analyze the diagnostic bus on a multi-head unit yet. Supporting these units will likely require firmware enhancements beyond what's currently implemented.
+
+The wiring diagrams for the following outdoor units include the diagnostic port:
+
+| Brand | Outdoor Models | Wiring Diagram |
+|---|---| ---|
+| MRCOOL | DIY-18-HP-C-230C, DIY-24-HP-C-230C, DIY-36-HP-C-230C  | [mc-diy-4-ah-sz-sm-en-01.pdf](https://doxrepo.mrcool.com/mc-diy-4-ah-sz-sm-en-01.pdf) |
+| Pioneer | YN009GMFI22RPE, YN012GMFI22RPE, YN009GMFI20RPD, YN012GMFI20RPD, YN018GMFI20RPD, YN009AMFI22RPE, YN012AMFI22RPE, YN009AMFI20RPD, YN012AMFI20RPD, YN018GMFI22RPE, YN024GMFI22RPE, YN024GMFI20RPD, YN030GMFI20RPD, YN036GMFI20RPD  | [WYS_SM.pdf](https://www.pdhvac.com/site/downloads/WYS_SM.pdf) |
+
+The following outdoor unit models reportedly lack a diagnostic port, or their wiring diagrams show no such port:
+
+| Brand | Outdoor Model | Wiring Diagram |
+|---|---|---|
+| Pioneer | YN036GLFI19RPE | n/a |
+| Carrier | 38MARBQ24AA3 | [SG-38MARB-02.pdf](https://www.shareddocs.com/hvac/docs/1009/Public/03/SG-38MARB-02.pdf) |
+
+## Hardware
+
+All you need is a **dual-core ESP32** and a level shifter. A dual core is required because the bus bit-banging runs in a dedicated FreeRTOS task. A full request/response cycle keeps the bus busy for ~380 ms, far too long to run on the main loop.
+
+<img src="images/schematics.png" width="400">
+
+Recommended hardware:
+- [XIAO ESP32S3](https://www.amazon.com/dp/B0BYSB66S5)
+- [3.3V–5V Level Shifter](https://www.amazon.com/dp/B07F7W91LC)
+
+I used the following connector kits, but you can get away with a single 4-pin male JST-XH connector:
+- [XH 2.54mm Connector Kit](https://www.amazon.com/dp/B08G18PWQ6)
+- [2.54mm Connector 4 Pin Male Adapter Right Angle](https://www.amazon.com/dp/B0BMDQLR4Q)
+
+### PCB & Enclosure
+
+The KiCad project, schematic, and Gerber files live in [pcb/](pcb/) - a 2-layer board, 41.5 × 22 mm, 1.6 mm thick, with four M2 mounting holes. You solder in just three parts - the ODU connector, the level-shifter module, and the XIAO - and that's the whole build. FreeCAD sources plus STL and 3MF exports for the 3D-printable enclosure are in [enclosure/](enclosure/).
+
+| PCB (top)  | PCB (bottom)  |
+| --- | --- |
+| ![Top](pcb/pcb-top.png) | ![Bottom](pcb/pcb-bottom.png) |
+
+| Assembled dongle | Enclosure |
+| --- | --- |
+| ![Prototype](images/prototype.jpg) | ![Enclosure](images/enclosure.png) |
+
+
+I've added a jumper that ties the diagnostic port's +5V to the XIAO's 5V pin. Use the jumper to run the board straight off the ODU with no USB cable. Leave it off if the board is connected to USB. I also recommend the use of a USB isolator since ground on the diagnostic port is not referenced to earth.
+
+## Safety
+
+The outdoor unit runs on mains voltage, and internal capacitors can retain a dangerous charge after being unplugged. Always
+
+- turn off the breaker,
+- pull the disconnect, and
+- wait several minutes and/or verify capacitors are discharged
+
+before performing the installation. Wear appropriate PPE. Consult a qualified electrician when in doubt.
+
+## Installation
+
+*(See [Safety](#safety) first if you're jumping straight to this section.)*
+
+Remove the top panel of the ODU. You'll see the control board. Remove the screws securing the control board to the ODU, then detach the cables from the cable clamps so you can lift the board for access — there's no need to unplug the cables themselves. The diagnostic port on my units is located at the front of the board. Plug in the dongle, with the red wire facing toward you. Reattach the cables to the cable clamps and secure the board back to the ODU. There should be enough clearance to tuck the dongle into the service panel — this lets you access the dongle later without needing to remove the control board again. Reinstall the top panel.
+
+| Control board | Diagnostic port |
+| --- | --- |
+| ![Install 1/4](images/install-1.png) | ![Install 2/4](images/install-2.png) |
+
+
+| Dongle plugged in | Dongle tucked into service panel |
+| --- | --- |
+| ![Install 3/4](images/install-3.png) | ![Install 4/4](images/install-4.png) |
+
+For a visual walkthrough, see [this installation video](https://www.youtube.com/watch?v=poEmSZnrnjs).
+
+## First use
+
+Upon first start, the dongle brings up a temporary WiFi hotspot so you can connect it to your WiFi network. Join the `midea-telemetry-esphome` network (password `midea-telemetry-esphome`) and provide your WiFi network's SSID and password in the popup that appears. Once connected, the dongle serves a webserver at `http://midea-telemetry.local` (useful if you don't run Home Assistant), and Home Assistant automatically detects it as a new ESPHome device.
+
+| WiFi hotspot | WiFi setup |
+| --- | --- |
+| ![Hotspot](images/hotspot.png) | ![Wi-Fi settings](images/wifi-settings.png) |
+
+| On-board webserver | Home Assistant auto-discovery |
+| --- | --- |
+| ![Webserver](images/webserver.png) | ![Device auto discovery](images/ha-auto-discovery.png) |
+
+## Configuration
+
+See [example_midea_telemetry.yaml](example_midea_telemetry.yaml) for a complete configuration with every supported sensor. That file uses a local `components:` source, so it's flashable straight from a checkout of this repo; to pull the component remotely instead, switch the source to `github://fmck3516/midea-telemetry-esphome` as shown below.
+
+The short version:
+
+```yaml
+external_components:
+  - source: github://fmck3516/midea-telemetry-esphome
+    components: [midea_telemetry]
+
+midea_telemetry:
+  clk_pin: GPIO3   # D2 on the XIAO ESP32S3
+  dat_pin: GPIO2   # D1
+  update_interval: 10s
+
+sensor:
+  - platform: midea_telemetry
+    outdoor_coil_temperature:
+      name: Outdoor coil temperature
+    compressor_frequency_actual_int:
+      name: Compressor frequency (actual, int)
+    # ... every field from the [Supported Sensors](#supported-sensors) table below is available
+```
+
+## Flashing
+
+Flash your ESP32 with `esphome`. On macOS:
+
+```sh
+brew install esphome
+esphome run example_midea_telemetry.yaml
+```
+
 ## Supported Sensors
 
 The following sensors are currently supported. `Code` is the two-letter parameter code the Midea
@@ -89,114 +218,7 @@ They behave like the decoded sensors: `state_class: measurement`, no unit (a byt
 
 **Enable only the bytes you are actually investigating.** All 49 publish on every poll, which is a lot of rows for Home Assistant's recorder database. For sustained observation across days, the [Grafana byte explorer](influxdb-grafana/RAW-BYTES.md) is the better tool — it charts the same bytes without touching Home Assistant at all. The firmware cost is small either way: nothing when none are enabled, about 1.7 KB of RAM and 3.4 KB of flash with all 49 on.
 
-## Prior Art
-
-I've documented the diagnostic bus protocol in great detail on Medium: [Reverse Engineering Midea's ODU Diagnostic Port](https://medium.com/@florian.mckee/reverse-engineering-mideas-odu-diagnostic-port-af603e159053). The firmware in this repository is based on those findings. Start there if you want to understand the protocol; the byte mappings and conversion formulas in the [Supported Sensors](#supported-sensors) table come straight from it.
-
-## Hardware
-
-All you need is a **dual-core ESP32** and a level shifter. A dual core is required because the bus bit-banging runs in a dedicated FreeRTOS task. A full request/response cycle keeps the bus busy for ~380 ms, far too long to run on the main loop.
-
-<img src="images/schematics.png" width="400">
-
-Recommended hardware:
-- [XIAO ESP32S3](https://www.amazon.com/dp/B0BYSB66S5)
-- [3.3V–5V Level Shifter](https://www.amazon.com/dp/B07F7W91LC)
-
-I used the following connector kits, but you can get away with a single 4-pin male JST-XH connector:
-- [XH 2.54mm Connector Kit](https://www.amazon.com/dp/B08G18PWQ6)
-- [2.54mm Connector 4 Pin Male Adapter Right Angle](https://www.amazon.com/dp/B0BMDQLR4Q)
-
-### PCB & Enclosure
-
-The KiCad project, schematic, and Gerber files live in [pcb/](pcb/) - a 2-layer board, 41.5 × 22 mm, 1.6 mm thick, with four M2 mounting holes. You solder in just three parts - the ODU connector, the level-shifter module, and the XIAO - and that's the whole build. FreeCAD sources plus STL and 3MF exports for the 3D-printable enclosure are in [enclosure/](enclosure/).
-
-| PCB (top)  | PCB (bottom)  |
-| --- | --- |
-| ![Top](pcb/pcb-top.png) | ![Bottom](pcb/pcb-bottom.png) |
-
-| Assembled dongle | Enclosure |
-| --- | --- |
-| ![Prototype](images/prototype.jpg) | ![Enclosure](images/enclosure.png) |
-
-
-I've added a jumper that ties the diagnostic port's +5V to the XIAO's 5V pin. Use the jumper to run the board straight off the ODU with no USB cable. Leave it off if the board is connected to USB. I also recommend the use of a USB isolator since ground on the diagnostic port is not referenced to earth.
-
-
-## Safety
-
-The outdoor unit runs on mains voltage, and internal capacitors can retain a dangerous charge after being unplugged. Always
-
-- turn off the breaker,
-- pull the disconnect, and
-- wait several minutes and/or verify capacitors are discharged
-
-before performing the installation. Wear appropriate PPE. Consult a qualified electrician when in doubt.
-
-## Installation
-
-*(See [Safety](#safety) first if you're jumping straight to this section.)*
-
-Remove the top panel of the ODU. You'll see the control board. Remove the screws securing the control board to the ODU, then detach the cables from the cable clamps so you can lift the board for access — there's no need to unplug the cables themselves. The diagnostic port on my units is located at the front of the board. Plug in the dongle, with the red wire facing toward you. Reattach the cables to the cable clamps and secure the board back to the ODU. There should be enough clearance to tuck the dongle into the service panel — this lets you access the dongle later without needing to remove the control board again. Reinstall the top panel.
-
-| Control board | Diagnostic port |
-| --- | --- |
-| ![Install 1/4](images/install-1.png) | ![Install 2/4](images/install-2.png) |
-
-
-| Dongle plugged in | Dongle tucked into service panel |
-| --- | --- |
-| ![Install 3/4](images/install-3.png) | ![Install 4/4](images/install-4.png) |
-
-For a visual walkthrough, see [this installation video](https://www.youtube.com/watch?v=poEmSZnrnjs).
-
-## First use
-
-Upon first start, the dongle brings up a temporary WiFi hotspot so you can connect it to your WiFi network. Join the `midea-telemetry-esphome` network (password `midea-telemetry-esphome`) and provide your WiFi network's SSID and password in the popup that appears. Once connected, the dongle serves a webserver at `http://midea-telemetry.local` (useful if you don't run Home Assistant), and Home Assistant automatically detects it as a new ESPHome device.
-
-| WiFi hotspot | WiFi setup |
-| --- | --- |
-| ![Hotspot](images/hotspot.png) | ![Wi-Fi settings](images/wifi-settings.png) |
-
-| On-board webserver | Home Assistant auto-discovery |
-| --- | --- |
-| ![Webserver](images/webserver.png) | ![Device auto discovery](images/ha-auto-discovery.png) |
-
-## Configuration
-
-See [example_midea_telemetry.yaml](example_midea_telemetry.yaml) for a complete configuration with every supported sensor. That file uses a local `components:` source, so it's flashable straight from a checkout of this repo; to pull the component remotely instead, switch the source to `github://fmck3516/midea-telemetry-esphome` as shown below.
-
-The short version:
-
-```yaml
-external_components:
-  - source: github://fmck3516/midea-telemetry-esphome
-    components: [midea_telemetry]
-
-midea_telemetry:
-  clk_pin: GPIO3   # D2 on the XIAO ESP32S3
-  dat_pin: GPIO2   # D1
-  update_interval: 10s
-
-sensor:
-  - platform: midea_telemetry
-    outdoor_coil_temperature:
-      name: Outdoor coil temperature
-    compressor_frequency_actual_int:
-      name: Compressor frequency (actual, int)
-    # ... every field from the Fields table below is available
-```
-
-## Flashing
-
-Flash your ESP32 with `esphome`. On macOS:
-
-```sh
-brew install esphome
-esphome run example_midea_telemetry.yaml
-```
-
-### JSON endpoint
+## JSON endpoint
 
 Add `expose_json_endpoint: true` to serve all mapped sensors and the underlying raw data as JSON. It needs the `web_server` component:
 
@@ -247,38 +269,15 @@ Example:
 
 This is useful for reverse engineering, scripting, and for using the device without Home Assistant.
 
-### Long-term history (InfluxDB + Grafana)
+## Long-term history (InfluxDB + Grafana)
 
 For a permanent, Home-Assistant-independent history, [`influxdb-grafana/`](influxdb-grafana/) provides a ready-to-run Docker stack: Telegraf polls each dongle's `/json` endpoint, stores the decoded values in InfluxDB v2, and Grafana serves a provisioned dashboard on top. Copy `.env.example` to `.env`, list your dongles in `telegraf.conf`, and `docker compose up -d`. See [influxdb-grafana/README.md](influxdb-grafana/README.md).
 
 ![Grafana Dashboard](images/grafana-dashboard.png)
 
-## Compatibility
+## Prior Art
 
-The dongle has been tested successfully with the following outdoor units:
-
-| Brand | Outdoor Models |
-|---|---|
-| MRCOOL | DIY-12-HP-C-115C25 |
-| Cooper&Hunter | CH-HPR06F9-230VO, CH-N36LCU-230VO |
-
-Since Midea-made mini-splits are very similar across brands, many other units from brands like MRCOOL, Cooper&Hunter, Senville, Pioneer, Blueridge, etc. are supported as well. Check your unit's wiring diagram, or look for a diagnostic port (white 4-pin JST connector labeled `TEST`) on the control board itself, to confirm.
-
-**Note**: I haven't had a chance to analyze the diagnostic bus on a multi-head unit yet. Supporting these units will likely require firmware enhancements beyond what's currently implemented.
-
-The wiring diagrams for the following outdoor units include the diagnostic port:
-
-| Brand | Outdoor Models | Wiring Diagram |
-|---|---| ---|
-| MRCOOL | DIY-18-HP-C-230C, DIY-24-HP-C-230C, DIY-36-HP-C-230C  | [mc-diy-4-ah-sz-sm-en-01.pdf](https://doxrepo.mrcool.com/mc-diy-4-ah-sz-sm-en-01.pdf) |
-| Pioneer | YN009GMFI22RPE, YN012GMFI22RPE, YN009GMFI20RPD, YN012GMFI20RPD, YN018GMFI20RPD, YN009AMFI22RPE, YN012AMFI22RPE, YN009AMFI20RPD, YN012AMFI20RPD, YN018GMFI22RPE, YN024GMFI22RPE, YN024GMFI20RPD, YN030GMFI20RPD, YN036GMFI20RPD  | [WYS_SM.pdf](https://www.pdhvac.com/site/downloads/WYS_SM.pdf) |
-
-The following outdoor unit models reportedly lack a diagnostic port, or their wiring diagrams show no such port:
-
-| Brand | Outdoor Model | Wiring Diagram |
-|---|---|---|
-| Pioneer | YN036GLFI19RPE | n/a |
-| Carrier | 38MARBQ24AA3 | [SG-38MARB-02.pdf](https://www.shareddocs.com/hvac/docs/1009/Public/03/SG-38MARB-02.pdf) |
+I've documented the diagnostic bus protocol in great detail on Medium: [Reverse Engineering Midea's ODU Diagnostic Port](https://medium.com/@florian.mckee/reverse-engineering-mideas-odu-diagnostic-port-af603e159053). The firmware in this repository is based on those findings. Start there if you want to understand the protocol; the byte mappings and conversion formulas in the [Supported Sensors](#supported-sensors) table come straight from it.
 
 ## Warranty
 

--- a/influxdb-grafana/README.md
+++ b/influxdb-grafana/README.md
@@ -69,7 +69,7 @@ and Grafana renders a provisioned dashboard on top — no Home Assistant require
 | Dashboard provider | `grafana/provisioning/dashboards/dashboards.yml` |
 | Dashboard | `grafana/dashboards/midea-telemetry.json` |
 
-The dashboard groups every field from the [Fields table](../README.md#fields):
+The dashboard groups every field from the [Supported Sensors table](../README.md#supported-sensors):
 coil/ambient temps, discharge temp, the compressor-frequency family
 (indoor/outdoor target, actual as int and float, and outdoor control —
 under the "Compressor Frequency (extended)" row at the bottom), outdoor fan


### PR DESCRIPTION
Closes #49.

The prose was fine. The **order** had drifted — sections accumulated where they were topically adjacent rather than where a reader needs them.

A newcomer's first question is whether this works with their unit. That was `## Compatibility`, at line 255 of 289, after Flashing and the JSON endpoint. Their second is what to buy — `## Hardware`, at line 96. Between the intro and anything actionable sat 83 lines, 29% of the document, of deep reference: the byte-mapping table, the NTC β-model, Steinhart–Hart, the two set-point encodings, the standby-current footnote, the operating-mode codes, and the 49 raw byte sensors. Evaluating the project meant scrolling past all of it to find out whether your model even has the port.

## New order

| | Before | After |
|---|---|---|
| 1 | Supported Sensors | Compatibility |
| 2 | Prior Art | Hardware |
| 3 | Hardware | Safety |
| 4 | Safety | Installation |
| 5 | Installation | First use |
| 6 | First use | Configuration |
| 7 | Configuration | Flashing |
| 8 | Flashing | Supported Sensors |
| 9 | ↳ JSON endpoint | JSON endpoint |
| 10 | ↳ Long-term history | Long-term history |
| 11 | Compatibility | Prior Art |
| 12 | Warranty / Disclaimer | Warranty / Disclaimer |

Decision path → build path → reference → about.

## Heading hierarchy

`### JSON endpoint` and `### Long-term history` were children of `## Flashing`. Neither is a sub-topic of flashing — `expose_json_endpoint: true` is a YAML key — and the nesting filed the document's **largest** section (51 lines) under its **smallest** (9 lines), while splitting configuration in two with an unrelated step in between. Both are promoted to `##`.

## Fossils fixed

Two leftovers from when the sensor table was called "Fields":

- `README.md` — "every field from the Fields table **below**" pointed at a table that was *above* it, under a name it no longer had. Now a working link to the table, which genuinely is below.
- `influxdb-grafana/README.md` — `[Fields table](../README.md#fields)` was a **broken anchor**. Now `#supported-sensors`.

## This is a move, not a rewrite

Verified by comparing the multiset of non-blank lines before and after. The only difference is the two promoted headings:

```
lines added:   ['## JSON endpoint', '## Long-term history (InfluxDB + Grafana)']
lines removed: ['### JSON endpoint', '### Long-term history (InfluxDB + Grafana)']
```

Everything else is byte-identical, relocated — so the diff reads as pure relocation and the +107/−108 is almost entirely movement.

**Every anchor that existed still exists.** GitHub derives anchors from heading *text*, not level, so both the reordering and the `###` → `##` promotions leave inbound deep links working, including any from the [Medium article](https://medium.com/@florian.mckee/reverse-engineering-mideas-odu-diagnostic-port-af603e159053) or from issues. The only anchor that changes is `#fields`, which was already broken. I checked every relative link and anchor across `README.md`, `influxdb-grafana/README.md` and `RAW-BYTES.md`: none broken.

## Deliberately not done

Extracting the ~30-line JSON sample out of `## JSON endpoint`. It would shorten the largest section considerably, but that is a content decision rather than a structural one — happy to open a separate issue if you want it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)